### PR TITLE
Added validation logic with further refactor

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -13,9 +13,6 @@ api-region: us-east-2
 # The default number of perspectives to use.
 default-perspective-count: 6
 
-# The default quorum to use.
-default-quorum: 5
-
 # Whether to enforce whether two distinct RIR regions must succeed.
 enforce-distinct-rir-regions: true
 

--- a/configure.py
+++ b/configure.py
@@ -94,10 +94,9 @@ def main(raw_args=None):
         main_tf_string = main_tf_string.replace("{{caa-resolver-arns-list}}", f"\"{arn_caa_resolver_list}\"")
         
 
-        # Replace default perspective count and default quorum.
+        # Replace default perspective count.
         main_tf_string = main_tf_string.replace("{{default-perspective-count}}", f"\"{config['default-perspective-count']}\"")
-        main_tf_string = main_tf_string.replace("{{default-quorum}}", f"\"{config['default-quorum']}\"")
-        
+
         # Replace enforce distinct rir regions.
         main_tf_string = main_tf_string.replace("{{enforce-distinct-rir-regions}}", f"\"{1 if config['enforce-distinct-rir-regions'] else 0}\"")
         

--- a/open-tofu/main.tf.template
+++ b/open-tofu/main.tf.template
@@ -77,7 +77,6 @@ resource "aws_lambda_function" "mpic_coordinator_lambda" {
         validator_arns = {{validator-arns-list}}
         caa_arns = {{caa-resolver-arns-list}}
         default_perspective_count = {{default-perspective-count}}
-        default_quorum = {{default-quorum}}
         enforce_distinct_rir_regions = {{enforce-distinct-rir-regions}}
         hash_secret = {{hash-secret}}
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ features = [
 
 [tool.hatch.envs.test.scripts]
 unit = "pytest"
+unit-html = "pytest --html=testreports/index.html" # generate html report (warning: uses an aging plugin, 11-2023)
 integration = "pytest tests/integration"
 coverage = "pytest --cov=src/aws_lambda_python --cov-report=term-missing --cov-report=html"
 
@@ -93,7 +94,6 @@ markers = [
 ]
 addopts = [
     "--import-mode=prepend",  # explicit default, as the tests rely on it for proper import resolution
-    "--html=testreports/index.html",  # generate html report (warning: uses an aging plugin, 11-2023)
     "--spec"  # show test names in a more readable format in the console (warning: uses an aging plugin, 5-2021)
 ]
 spec_header_format = "Spec for {test_case} ({path}):"

--- a/src/aws_lambda_python/mpic_coordinator/config/service_config.py
+++ b/src/aws_lambda_python/mpic_coordinator/config/service_config.py
@@ -1,0 +1,2 @@
+#  TODO discuss, is this meant to correlate to the Open-MPIC API version? or this API's version? or kinda both?
+API_VERSION = "1.0.0"  # update this as needed, to correspond to the implemented version of the Open-MPIC API spec.

--- a/src/aws_lambda_python/mpic_coordinator/domain/check_type.py
+++ b/src/aws_lambda_python/mpic_coordinator/domain/check_type.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class CheckType(StrEnum):
+    CAA = 'caa'
+    DCV = 'dcv'
+

--- a/src/aws_lambda_python/mpic_coordinator/domain/remote_check_call_configuration.py
+++ b/src/aws_lambda_python/mpic_coordinator/domain/remote_check_call_configuration.py
@@ -2,8 +2,8 @@ from aws_lambda_python.mpic_coordinator.domain.check_type import CheckType
 
 
 class RemoteCheckCallConfiguration:
-    def __init__(self, check_type: CheckType, perspective: str, lambda_arn: str, args: dict):
+    def __init__(self, check_type: CheckType, perspective: str, lambda_arn: str, input_args: dict):
         self.check_type = check_type
         self.lambda_arn = lambda_arn
         self.perspective = perspective
-        self.args = args
+        self.input_args = input_args

--- a/src/aws_lambda_python/mpic_coordinator/domain/remote_check_call_configuration.py
+++ b/src/aws_lambda_python/mpic_coordinator/domain/remote_check_call_configuration.py
@@ -1,0 +1,9 @@
+from aws_lambda_python.mpic_coordinator.domain.check_type import CheckType
+
+
+class RemoteCheckCallConfiguration:
+    def __init__(self, check_type: CheckType, perspective: str, lambda_arn: str, args: dict):
+        self.check_type = check_type
+        self.lambda_arn = lambda_arn
+        self.perspective = perspective
+        self.args = args

--- a/src/aws_lambda_python/mpic_coordinator/domain/request_path.py
+++ b/src/aws_lambda_python/mpic_coordinator/domain/request_path.py
@@ -1,7 +1,7 @@
 from enum import StrEnum
 
 
-class RequestPaths(StrEnum):
+class RequestPath(StrEnum):
     CAA_CHECK = '/caa-check'
     DCV_CHECK = '/validation'
     DCV_WITH_CAA_CHECK = '/validation-with-caa-check'

--- a/src/aws_lambda_python/mpic_coordinator/domain/request_paths.py
+++ b/src/aws_lambda_python/mpic_coordinator/domain/request_paths.py
@@ -1,0 +1,7 @@
+from enum import StrEnum
+
+
+class RequestPaths(StrEnum):
+    CAA_CHECK = '/caa-check'
+    DCV_CHECK = '/validation'
+    DCV_WITH_CAA_CHECK = '/validation-with-caa-check'

--- a/src/aws_lambda_python/mpic_coordinator/messages/validation_messages.py
+++ b/src/aws_lambda_python/mpic_coordinator/messages/validation_messages.py
@@ -2,19 +2,24 @@ from enum import Enum
 
 
 class ValidationMessages(Enum):
-    MISSING_API_VERSION = ("missing-api-version", "Missing API version in request.")
-    INVALID_API_VERSION = ("invalid-api-version", "Invalid API version specified: {0}")
-    # TODO the ones below were auto-added by copilot, replace them once this is all working
-    INVALID_QUORUM_COUNT = ("invalid_quorum_count", "Invalid quorum count: {0}")
-    MISSING_CERTIFICATE_TYPE = ("missing_certificate_type", "Missing certificate type in CAA details.")
-    INVALID_CERTIFICATE_TYPE = ("invalid_certificate_type", "Invalid certificate type specified: {0}")
-    MISSING_VALIDATION_METHOD = ("missing_validation_method", "Missing validation method for DCV.")
-    INVALID_VALIDATION_METHOD = ("invalid_validation_method", "Invalid validation method specified: {0}")
-    MISSING_VALIDATION_DETAILS = ("missing_validation_details", "Missing validation details for DCV.")
-    MISSING_EXPECTED_CHALLENGE = ("missing_expected_challenge", "Missing expected challenge in validation details for {0}.")
-    MISSING_PREFIX = ("missing_prefix", "Missing prefix in validation details for DNS validation.")
-    MISSING_RECORD_TYPE = ("missing_record_type", "Missing record type in validation details for DNS validation.")
-    MISSING_PATH = ("missing_path", "Missing path in validation details for HTTP validation.")
+    MISSING_API_VERSION = ("missing-api-version", "Missing 'api-version' in request.")
+    INVALID_API_VERSION = ("invalid-api-version", "Invalid 'api-version' specified: {0}")
+    UNSUPPORTED_REQUEST_PATH = ("unsupported-request-path", "Unsupported request path: {0}")
+    MISSING_SYSTEM_PARAMS = ("missing-system-params", "Missing 'system-params' in request.")
+    MISSING_DOMAIN_OR_IP_TARGET = ("missing-domain-or-ip-target", "Missing 'identifier' in 'system-params'.")  # TODO rename 'identifier'
+    PERSPECTIVES_WITH_PERSPECTIVE_COUNT = ("contains-both-perspectives-and-perspective-count", "Request contains both 'perspectives' and 'perspective-count'.")
+    INVALID_PERSPECTIVE_COUNT = ("invalid-perspective-count", "Invalid perspective count: {0}")
+    INVALID_PERSPECTIVE_LIST = ("invalid-perspective-list", "Invalid perspective list specified.")
+    INVALID_QUORUM_COUNT = ("invalid-quorum-count", "Invalid quorum count: {0}")
+    INVALID_CERTIFICATE_TYPE = ("invalid-certificate-type", "Invalid 'certificate-type' specified: {0}")
+    MISSING_VALIDATION_METHOD = ("missing-validation-method", "Missing 'validation-method' for DCV.")
+    INVALID_VALIDATION_METHOD = ("invalid-validation-method", "Invalid 'validation-method' specified: {0}")
+    MISSING_VALIDATION_DETAILS = ("missing-validation-details", "Missing 'validation-details' for DCV.")
+    MISSING_EXPECTED_CHALLENGE = ("missing-expected-challenge", "Missing 'expected-challenge' in validation details for {0}.")
+    MISSING_PREFIX = ("missing-prefix", "Missing 'prefix' in validation details for DNS validation.")
+    MISSING_RECORD_TYPE = ("missing-record-type", "Missing 'record-type' in validation details for DNS validation.")
+    MISSING_PATH = ("missing-path", "Missing 'path' in validation details for HTTP validation.")
+    REQUEST_VALIDATION_FAILED = ("request-validation-failed", "Request validation failed.")
 
     def __init__(self, key, message):
         self.key = key

--- a/src/aws_lambda_python/mpic_coordinator/messages/validation_messages.py
+++ b/src/aws_lambda_python/mpic_coordinator/messages/validation_messages.py
@@ -1,0 +1,21 @@
+from enum import Enum
+
+
+class ValidationMessages(Enum):
+    MISSING_API_VERSION = ("missing-api-version", "Missing API version in request.")
+    INVALID_API_VERSION = ("invalid-api-version", "Invalid API version specified: {0}")
+    # TODO the ones below were auto-added by copilot, replace them once this is all working
+    INVALID_QUORUM_COUNT = ("invalid_quorum_count", "Invalid quorum count: {0}")
+    MISSING_CERTIFICATE_TYPE = ("missing_certificate_type", "Missing certificate type in CAA details.")
+    INVALID_CERTIFICATE_TYPE = ("invalid_certificate_type", "Invalid certificate type specified: {0}")
+    MISSING_VALIDATION_METHOD = ("missing_validation_method", "Missing validation method for DCV.")
+    INVALID_VALIDATION_METHOD = ("invalid_validation_method", "Invalid validation method specified: {0}")
+    MISSING_VALIDATION_DETAILS = ("missing_validation_details", "Missing validation details for DCV.")
+    MISSING_EXPECTED_CHALLENGE = ("missing_expected_challenge", "Missing expected challenge in validation details for {0}.")
+    MISSING_PREFIX = ("missing_prefix", "Missing prefix in validation details for DNS validation.")
+    MISSING_RECORD_TYPE = ("missing_record_type", "Missing record type in validation details for DNS validation.")
+    MISSING_PATH = ("missing_path", "Missing path in validation details for HTTP validation.")
+
+    def __init__(self, key, message):
+        self.key = key
+        self.message = message

--- a/src/aws_lambda_python/mpic_coordinator/mpic_coordinator.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_coordinator.py
@@ -178,8 +178,9 @@ class MpicCoordinator:
         # TODO update API -- required-quorum-count is not there today and probably should be if it's dynamically derived
         resp_body = {
             'api-version': VERSION,
-            'system-params': system_params,
-            'required-quorum-count': quorum_count,
+            'request-system-params': system_params,  # TODO rename this field in API
+            'number-of-perspectives-used': perspective_count,  # TODO add this field to API
+            'required-quorum-count-used': quorum_count,  # TODO add this field to API
         }
 
         match request_path:

--- a/src/aws_lambda_python/mpic_coordinator/mpic_coordinator.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_coordinator.py
@@ -7,7 +7,7 @@ import os
 import random
 import hashlib
 
-VERSION = "1.0.0"  # TODO do we need to externalize this to an environment variable? it's a bit hidden here
+VERSION = "1.0.0"  # TODO do we need to externalize this? it's a bit hidden here
 
 
 class MpicCoordinator:
@@ -86,7 +86,9 @@ class MpicCoordinator:
         request_path = event["path"]
         body = json.loads(event["body"])
 
-        # TODO should we check for missing api-version, system-params, and other required fields here?
+        # TODO validate request here (then can remove some of the below checks which will become redundant)
+
+        # TODO error messages probably should live in their own class, otherwise the code will get cumbersome quickly
 
         # Begin with an API version check.
         request_api_version_split = body['api-version'].split('.')

--- a/src/aws_lambda_python/mpic_coordinator/mpic_coordinator.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_coordinator.py
@@ -129,15 +129,14 @@ class MpicCoordinator:
 
     # Configures the async lambda function calls to issue for the check request.
     def collect_async_calls_to_issue(self, request_path, body, perspectives_to_use) -> list[RemoteCheckCallConfiguration]:
-        domain_or_ip_target = body['system-params'][
-            'identifier']  # should have already checked for validity by this point
+        domain_or_ip_target = body['system-params']['identifier']  # should have checked for validity by this point
         async_calls_to_issue = []
 
         # TODO are validation-method and validation-details required but caa-details NOT required?
 
         if request_path in (RequestPath.CAA_CHECK, RequestPath.DCV_WITH_CAA_CHECK):
             input_args = {'identifier': domain_or_ip_target,
-                          'caa-params': body['caa-details'] if 'caa-details' in body else {}}
+                          'caa-params': body['caa-details'] if 'caa-details' in body else {}}  # TODO why 'params' vs 'details'?
             for perspective in perspectives_to_use:
                 arn = self.arns_per_perspective_per_check_type[CheckType.CAA][perspective]
                 call_config = RemoteCheckCallConfiguration(CheckType.CAA, perspective, arn, input_args)
@@ -146,7 +145,7 @@ class MpicCoordinator:
         if request_path in (RequestPath.DCV_CHECK, RequestPath.DCV_WITH_CAA_CHECK):
             input_args = {'identifier': domain_or_ip_target,
                           'validation-method': body['validation-method'],
-                          'validation-params': body['validation-details']}
+                          'validation-params': body['validation-details']}  # TODO why 'params' vs 'details'?
             for perspective in perspectives_to_use:
                 arn = self.arns_per_perspective_per_check_type[CheckType.DCV][perspective]
                 call_config = RemoteCheckCallConfiguration(CheckType.DCV, perspective, arn, input_args)

--- a/src/aws_lambda_python/mpic_coordinator/mpic_coordinator.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_coordinator.py
@@ -1,4 +1,5 @@
 import json
+from typing import Final
 import boto3
 import time
 import concurrent.futures
@@ -7,16 +8,19 @@ import os
 import random
 import hashlib
 
+from aws_lambda_python.mpic_coordinator.domain.check_type import CheckType
+from aws_lambda_python.mpic_coordinator.domain.remote_check_call_configuration import RemoteCheckCallConfiguration
+from aws_lambda_python.mpic_coordinator.domain.request_paths import RequestPaths
 from aws_lambda_python.mpic_coordinator.messages.validation_messages import ValidationMessages
 from aws_lambda_python.mpic_coordinator.mpic_request_validator import MpicRequestValidator
 
-VERSION = "1.0.0"  # TODO do we need to externalize this? it's a bit hidden here
+VERSION: Final[str] = '1.0.0'  # TODO do we need to externalize this? it's a bit hidden here
 
 
 class MpicCoordinator:
     def __init__(self):
         # Load lists of perspective names, validator arns, and caa arns from environment vars.
-        self.perspective_name_list = os.environ['perspective_names'].split("|")
+        self.known_perspectives = os.environ['perspective_names'].split("|")
         self.validator_arn_list = os.environ['validator_arns'].split("|")
         self.caa_arn_list = os.environ['caa_arns'].split("|")
         self.default_perspective_count = int(os.environ['default_perspective_count'])
@@ -24,28 +28,29 @@ class MpicCoordinator:
         self.enforce_distinct_rir_regions = int(os.environ['enforce_distinct_rir_regions']) == 1
         self.hash_secret = os.environ['hash_secret']
 
-        self.func_arns = {
-            'validations': {self.perspective_name_list[i]: self.validator_arn_list[i] for i in
-                            range(len(self.perspective_name_list))},
-            'caa': {self.perspective_name_list[i]: self.caa_arn_list[i] for i in range(len(self.perspective_name_list))}
+        # Create a dictionary of ARNs per check type per perspective to simplify lookup in the future.
+        # (Assumes known_perspectives list, validator_arn_list, and caa_arn_list are the same length.)
+        self.arns_per_check = {
+            CheckType.DCV: {self.known_perspectives[i]: self.validator_arn_list[i] for i in range(len(self.known_perspectives))},
+            CheckType.CAA: {self.known_perspectives[i]: self.caa_arn_list[i] for i in range(len(self.known_perspectives))}
         }
 
     @staticmethod
-    def thread_call(lambda_arn, region, input_params):
-        print(f"Started lambda call for region {region} at {str(datetime.now())}")
+    def thread_call(call_config: RemoteCheckCallConfiguration):
+        print(f"Started lambda call for region {call_config.perspective} at {str(datetime.now())}")
 
         tic_init = time.perf_counter()
-        client = boto3.client('lambda', region.split(".")[1])
+        client = boto3.client('lambda', call_config.perspective.split(".")[1])
         tic = time.perf_counter()
         response = client.invoke(
-            FunctionName=lambda_arn,
+            FunctionName=call_config.lambda_arn,
             InvocationType='RequestResponse',
-            Payload=json.dumps(input_params)
+            Payload=json.dumps(call_config.args)
         )
         toc = time.perf_counter()
 
-        print(f"Response in region {region} took {toc - tic:0.4f} seconds to get response; {tic - tic_init:.2f} \
-                seconds to start boto client; ended at {str(datetime.now())}\n")
+        print(f"Response in region {call_config.perspective} took {toc - tic:0.4f} seconds to get response; \
+              {tic - tic_init:.2f} seconds to start boto client; ended at {str(datetime.now())}\n")
         return response
 
     # Returns a random subset of perspectives with a goal of maximum RIR diversity to increase diversity.
@@ -86,12 +91,13 @@ class MpicCoordinator:
         return chosen_perspectives
 
     def coordinate_mpic(self, event):
-        request_path = event["path"]
-        body = json.loads(event["body"])
+        request_path = event['path']
+        body = json.loads(event['body'])
 
         # TODO validate the request path?
 
-        is_request_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(request_path, body, self.perspective_name_list)
+        is_request_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(request_path, body,
+                                                                                              self.known_perspectives)
         if not is_request_body_valid:
             return {
                 'statusCode': 400,
@@ -113,7 +119,9 @@ class MpicCoordinator:
         else:
             if 'perspective-count' in system_params:
                 perspective_count = system_params['perspective-count']
-            perspectives_to_use = self.random_select_perspectives_considering_rir(self.perspective_name_list, perspective_count, domain_or_ip_target)
+            perspectives_to_use = self.random_select_perspectives_considering_rir(self.known_perspectives,
+                                                                                  perspective_count,
+                                                                                  domain_or_ip_target)
 
         # FIXME default_quorum should follow BRs -- if perspectives <=5, quorum is perspectives-1, else perspectives-2
         # otherwise could have, for example, 10 perspectives and default quorum of 5 which is too low
@@ -122,58 +130,30 @@ class MpicCoordinator:
             quorum_count = system_params['quorum-count']
 
         # Collect async calls to invoke for each perspective.
-        async_calls_to_invoke = self.collect_async_calls_to_issue(request_path, body, perspectives_to_use)
+        async_calls_to_issue = self.collect_async_calls_to_issue(request_path, body, perspectives_to_use)
 
-        perspective_responses = {}
-        valid_by_perspective_by_op_type = {'validation': {r: False for r in perspectives_to_use},
-                                           'caa': {r: False for r in perspectives_to_use}}
+        perspective_responses_per_check_type, validity_per_perspective_per_check_type = (
+            self.issue_async_calls_and_collect_responses(perspectives_to_use, async_calls_to_issue))
 
-        # example code: https://docs.python.org/3/library/concurrent.futures.html
-        with concurrent.futures.ThreadPoolExecutor(max_workers=perspective_count) as executor:
-            exec_begin = time.perf_counter()
-            future_to_dv = {executor.submit(self.thread_call, arn, perspective, args): (perspective, optype) for
-                            (optype, perspective, arn, args) in async_calls_to_invoke}
-            for future in concurrent.futures.as_completed(future_to_dv):
-                perspective, optype = future_to_dv[future]
-                now = time.perf_counter()
-                print(
-                    f"Unpacking future result for {perspective} at time {str(datetime.now())}: {now - exec_begin:.2f} \
-                    seconds from beginning")
-                try:
-                    data = future.result()
-                except Exception as exc:
-                    print(f'{perspective} generated an exception: {exc}')
-                else:
-                    persp_resp = json.loads(data['Payload'].read().decode('utf-8'))
-                    print(persp_resp)  # Debugging
-                    persp_resp_body = json.loads(persp_resp['body'])
-                    if persp_resp_body['ValidForIssue']:
-                        print(f"Perspective in {persp_resp_body['Region']} was valid!")
-                    valid_by_perspective_by_op_type[optype][perspective] |= persp_resp_body['ValidForIssue']
-                    if optype not in perspective_responses:
-                        perspective_responses[optype] = []
-                    perspective_responses[optype].append(persp_resp)
-
-        valid_by_op_type = {}
-        two_rir_regions_by_op_type = {}
-        for optype in ['validation', 'caa']:
-            valid_perspective_count = sum(valid_by_perspective_by_op_type[optype].values())
+        valid_by_check_type = {}
+        two_rir_regions_by_check_type = {}
+        for check_type in [CheckType.CAA, CheckType.DCV]:
+            valid_perspective_count = sum(validity_per_perspective_per_check_type[check_type].values())
 
             # Create a list of valid perspectives.
-            valid_perspectives = [perspective for perspective in valid_by_perspective_by_op_type[optype] if
-                                  valid_by_perspective_by_op_type[optype][perspective]]
+            valid_perspectives = [perspective for perspective in validity_per_perspective_per_check_type[check_type] if
+                                  validity_per_perspective_per_check_type[check_type][perspective]]
 
             # Create a list of RIRs that have a valid perspective.
             valid_rirs = [perspective.split(".")[0] for perspective in valid_perspectives]
 
             distinct_valid_rirs = set(valid_rirs)
             print(len(distinct_valid_rirs))
-            two_rir_regions_by_op_type[optype] = len(distinct_valid_rirs) >= 2
+            two_rir_regions_by_check_type[check_type] = len(distinct_valid_rirs) >= 2
 
-            # Todo: optionally enforce 2 distinct RIR policy.
-            print(
-                f"overall OK to issue for {optype}? {valid_perspective_count >= quorum_count} num valid VPs: {valid_perspective_count} num to meet quorum: {quorum_count}")
-            valid_by_op_type[optype] = valid_perspective_count >= quorum_count
+            # TODO optionally enforce 2 distinct RIR policy.
+
+            valid_by_check_type[check_type] = valid_perspective_count >= quorum_count
 
         # TODO update API -- required-quorum-count is not there today and probably should be if it's dynamically derived
         resp_body = {
@@ -182,27 +162,28 @@ class MpicCoordinator:
             'number-of-perspectives-used': perspective_count,  # TODO add this field to API
             'required-quorum-count-used': quorum_count,  # TODO add this field to API
         }
+        # TODO add number of retries once retry logic is in place
 
         match request_path:
-            case '/caa-check':
-                resp_body['perspectives'] = perspective_responses['caa']
-                resp_body['is-valid'] = valid_by_op_type['caa'] and (
-                        not self.enforce_distinct_rir_regions or two_rir_regions_by_op_type['caa'])
-            case '/validation':
-                resp_body['perspectives'] = perspective_responses['validation']
+            case RequestPaths.CAA_CHECK:
+                resp_body['perspectives'] = perspective_responses_per_check_type[CheckType.CAA]
+                resp_body['is-valid'] = valid_by_check_type[CheckType.CAA] and (
+                        not self.enforce_distinct_rir_regions or two_rir_regions_by_check_type[CheckType.CAA])
+            case RequestPaths.DCV_CHECK:
+                resp_body['perspectives'] = perspective_responses_per_check_type[CheckType.DCV]
                 resp_body['validation-details'] = body['validation-details']
                 resp_body['validation-method'] = body['validation-method']
-                resp_body['is-valid'] = valid_by_op_type['validation'] and (
-                        not self.enforce_distinct_rir_regions or two_rir_regions_by_op_type['validation'])
-            case '/validation-with-caa-check':
-                resp_body['perspectives-validation'] = perspective_responses['validation']
-                resp_body['perspectives-caa'] = perspective_responses['caa']
+                resp_body['is-valid'] = valid_by_check_type[CheckType.DCV] and (
+                        not self.enforce_distinct_rir_regions or two_rir_regions_by_check_type[CheckType.DCV])
+            case RequestPaths.DCV_WITH_CAA_CHECK:
+                resp_body['perspectives-validation'] = perspective_responses_per_check_type['validation']
+                resp_body['perspectives-caa'] = perspective_responses_per_check_type['caa']
                 resp_body['validation-details'] = body['validation-details']
                 resp_body['validation-method'] = body['validation-method']
-                resp_body['is-valid-validation'] = valid_by_op_type['validation'] and (
-                        not self.enforce_distinct_rir_regions or two_rir_regions_by_op_type['validation'])
-                resp_body['is-valid-caa'] = valid_by_op_type['caa'] and (
-                        not self.enforce_distinct_rir_regions or two_rir_regions_by_op_type['caa'])
+                resp_body['is-valid-validation'] = valid_by_check_type[CheckType.DCV] and (
+                        not self.enforce_distinct_rir_regions or two_rir_regions_by_check_type[CheckType.DCV])
+                resp_body['is-valid-caa'] = valid_by_check_type[CheckType.CAA] and (
+                        not self.enforce_distinct_rir_regions or two_rir_regions_by_check_type[CheckType.CAA])
                 resp_body['is-valid'] = resp_body['is-valid-validation'] and resp_body['is-valid-caa']
 
         return {
@@ -210,34 +191,66 @@ class MpicCoordinator:
             'body': json.dumps(resp_body)
         }
 
-    def collect_async_calls_to_issue(self, request_path, body, perspectives_to_use):
-        identifier = body['system-params']['identifier']  # should have already checked for validity by this point
-        async_calls_to_invoke = []
+    def collect_async_calls_to_issue(self, request_path, body, perspectives_to_use) -> list[RemoteCheckCallConfiguration]:
+        domain_or_ip_target = body['system-params'][
+            'identifier']  # should have already checked for validity by this point
+        async_calls_to_issue = []
 
         # TODO are validation-method and validation-details required but caa-details NOT required?
 
-        match request_path:
-            case '/caa-check':
-                input_args = {'identifier': identifier,
-                              'caa-params': body['caa-details'] if 'caa-details' in body else {}}
-                for perspective in perspectives_to_use:
-                    arn = self.func_arns['caa'][perspective]
-                    async_calls_to_invoke.append(('caa', perspective, arn, input_args))
-            case '/validation':
-                perspective_arns = self.func_arns['validations']
-                input_args = {'identifier': identifier,
-                              'validation-method': body['validation-method'],
-                              'validation-params': body['validation-details']}
-                for perspective in perspectives_to_use:
-                    arn = perspective_arns[perspective]
-                    async_calls_to_invoke.append(('validation', perspective, arn, input_args))
-            case '/validation-with-caa-check':
-                for perspective in perspectives_to_use:
-                    async_calls_to_invoke.append(("caa", perspective, self.func_arns['caa'][perspective],
-                                                  {'identifier': identifier,
-                                                   'caa-params': body['caa-details'] if 'caa-details' in body else {}}))
-                    async_calls_to_invoke.append(('validation', perspective, self.func_arns['validations'][perspective],
-                                                  {'identifier': identifier,
-                                                   'validation-method': body['validation-method'],
-                                                   'validation-params': body['validation-details']}))
-        return async_calls_to_invoke
+        if request_path in (RequestPaths.CAA_CHECK, RequestPaths.DCV_WITH_CAA_CHECK):
+            input_args = {'identifier': domain_or_ip_target,
+                          'caa-params': body['caa-details'] if 'caa-details' in body else {}}
+            for perspective in perspectives_to_use:
+                arn = self.arns_per_check[CheckType.CAA][perspective]
+                call_config = RemoteCheckCallConfiguration(CheckType.CAA, perspective, arn, input_args)
+                async_calls_to_issue.append(call_config)
+
+        if request_path in (RequestPaths.DCV_CHECK, RequestPaths.DCV_WITH_CAA_CHECK):
+            perspective_arns = self.arns_per_check[CheckType.DCV]
+            input_args = {'identifier': domain_or_ip_target,
+                          'validation-method': body['validation-method'],
+                          'validation-params': body['validation-details']}
+            for perspective in perspectives_to_use:
+                arn = perspective_arns[perspective]
+                call_config = RemoteCheckCallConfiguration(CheckType.DCV, perspective, arn, input_args)
+                async_calls_to_issue.append(call_config)
+
+        return async_calls_to_issue
+
+    def issue_async_calls_and_collect_responses(self, perspectives_to_use, async_calls_to_issue) -> (dict, dict):
+        perspective_responses_per_check_type = {}
+        validity_per_perspective_per_check_type = {CheckType.CAA: {r: False for r in perspectives_to_use},
+                                                   CheckType.DCV: {r: False for r in perspectives_to_use}}
+
+        perspective_count = len(perspectives_to_use)
+
+        # example code: https://docs.python.org/3/library/concurrent.futures.html
+        with concurrent.futures.ThreadPoolExecutor(max_workers=perspective_count) as executor:
+            exec_begin = time.perf_counter()
+            futures_to_call_configs = {executor.submit(self.thread_call, call_config): call_config for call_config in
+                                       async_calls_to_issue}
+            for future in concurrent.futures.as_completed(futures_to_call_configs):
+                call_configuration = futures_to_call_configs[future]
+                perspective = call_configuration.perspective
+                check_type = call_configuration.check_type
+                now = time.perf_counter()
+                print(
+                    f"Unpacking future result for {perspective} at time {str(datetime.now())}: {now - exec_begin:.2f} \
+                    seconds from beginning")
+                try:
+                    data = future.result()
+                except Exception as e:
+                    print(f'{perspective} generated an exception: {e}')
+                else:
+                    perspective_response = json.loads(data['Payload'].read().decode('utf-8'))
+                    print(perspective_response)  # Debugging
+                    perspective_response_body = json.loads(perspective_response['body'])
+                    if perspective_response_body['ValidForIssue']:
+                        print(f"Perspective in {perspective_response_body['Region']} was valid!")
+                    validity_per_perspective_per_check_type[check_type][perspective] |= perspective_response_body[
+                        'ValidForIssue']
+                    if check_type not in perspective_responses_per_check_type:
+                        perspective_responses_per_check_type[check_type] = []
+                    perspective_responses_per_check_type[check_type].append(perspective_response)
+        return perspective_responses_per_check_type, validity_per_perspective_per_check_type

--- a/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
@@ -29,7 +29,7 @@ class MpicRequestValidator:
             if 'perspectives' in request_body['system-params'] and 'perspective-count' in request_body['system-params']:
                 request_body_validation_issues.append(ValidationIssue(ValidationMessages.PERSPECTIVES_WITH_PERSPECTIVE_COUNT))
             elif 'perspectives' in request_body['system-params']:
-                requested_perspectives = request_body['system-params']['perspectives'].split('|')
+                requested_perspectives = request_body['system-params']['perspectives']
                 MpicRequestValidator.validate_requested_perspectives(requested_perspectives, known_perspectives, request_body_validation_issues)
             elif 'perspective-count' in request_body['system-params']:
                 requested_perspective_count = request_body['system-params']['perspective-count']

--- a/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
@@ -2,6 +2,7 @@ import numbers
 import re
 from aws_lambda_python.mpic_coordinator.domain.certificate_type import CertificateType
 from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvValidationMethod
+from aws_lambda_python.mpic_coordinator.domain.request_paths import RequestPaths
 from aws_lambda_python.mpic_coordinator.messages.validation_messages import ValidationMessages
 from aws_lambda_python.mpic_coordinator.validation_issue import ValidationIssue
 
@@ -39,10 +40,10 @@ class MpicRequestValidator:
         # for example, if request_path == '/caa-check', then enforce that 'caa-details' is present
         # and that 'validation-details' is not present
         match request_path:
-            case '/caa-check':
+            case RequestPaths.CAA_CHECK | RequestPaths.DCV_WITH_CAA_CHECK:
                 if 'caa-details' in request_body:
                     MpicRequestValidator.validate_caa_check_request_details(request_body, request_body_validation_issues)
-            case '/validation':
+            case RequestPaths.DCV_CHECK | RequestPaths.DCV_WITH_CAA_CHECK:
                 MpicRequestValidator.validate_dcv_check_request_details(request_body, request_body_validation_issues)
             case _:
                 request_body_validation_issues.append(ValidationIssue(ValidationMessages.UNSUPPORTED_REQUEST_PATH, request_path))

--- a/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
@@ -1,3 +1,4 @@
+import numbers
 import re
 from aws_lambda_python.mpic_coordinator.domain.certificate_type import CertificateType
 from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvValidationMethod
@@ -9,7 +10,7 @@ class MpicRequestValidator:
     @staticmethod
     # returns a list of validation issues found in the request body; if empty, request body is valid
     # TODO return upon finding first validation issue? or accumulate issues? accumulating is more "helpful" to caller
-    def is_request_body_valid(request_path, request_body):
+    def is_request_body_valid(request_path, request_body, known_perspectives) -> (bool, list):
         request_body_validation_issues = []
 
         # enforce presence of required fields
@@ -19,14 +20,20 @@ class MpicRequestValidator:
             MpicRequestValidator.validate_api_version(request_body['api-version'], request_body_validation_issues)
 
         if 'system-params' not in request_body:
-            request_body_validation_issues.append('missing-system-params')
+            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_SYSTEM_PARAMS))
         else:  # TODO rename 'identifier' to something more descriptive in the spec, then fix this error message
             if 'identifier' not in request_body['system-params']:
-                request_body_validation_issues.append('missing-domain-or-ip-target')
+                request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_DOMAIN_OR_IP_TARGET))
 
             # enforce that only one of 'perspectives' or 'perspective-count' is present
             if 'perspectives' in request_body['system-params'] and 'perspective-count' in request_body['system-params']:
-                request_body_validation_issues.append('contains-both-perspectives-and-perspective-count')
+                request_body_validation_issues.append(ValidationIssue(ValidationMessages.PERSPECTIVES_WITH_PERSPECTIVE_COUNT))
+            elif 'perspectives' in request_body['system-params']:
+                requested_perspectives = request_body['system-params']['perspectives'].split('|')
+                MpicRequestValidator.validate_requested_perspectives(requested_perspectives, known_perspectives, request_body_validation_issues)
+            elif 'perspective-count' in request_body['system-params']:
+                requested_perspective_count = request_body['system-params']['perspective-count']
+                MpicRequestValidator.validate_requested_perspective_count(requested_perspective_count, known_perspectives, request_body_validation_issues)
 
         # have a switch based on request path to enforce additional validation rules
         # for example, if request_path == '/caa-check', then enforce that 'caa-details' is present
@@ -38,7 +45,7 @@ class MpicRequestValidator:
             case '/validation':
                 MpicRequestValidator.validate_dcv_check_request_details(request_body, request_body_validation_issues)
             case _:
-                request_body_validation_issues.append('unsupported-request-path')
+                request_body_validation_issues.append(ValidationIssue(ValidationMessages.UNSUPPORTED_REQUEST_PATH, request_path))
 
         # returns true if no validation issues found, false otherwise; includes list of validation issues found
         return len(request_body_validation_issues) == 0, request_body_validation_issues
@@ -46,44 +53,42 @@ class MpicRequestValidator:
     @staticmethod
     def validate_caa_check_request_details(request_body, request_body_validation_issues) -> None:
         if 'caa-details' in request_body:
-            # TODO is there a default certificate type we should use if not specified? (then field _can_ be missing)
-            if 'certificate-type' not in request_body['caa-details']:
-                request_body_validation_issues.append('missing-certificate-type-in-caa-details')
-            else:
+            if 'certificate-type' in request_body['caa-details']:
                 certificate_type = request_body['caa-details']['certificate-type']
                 # check if certificate_type is not in CertificateType enum
                 if certificate_type not in iter(CertificateType):
-                    request_body_validation_issues.append('invalid-certificate-type-in-caa-details')
+                    request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_CERTIFICATE_TYPE, certificate_type))
                 # TODO do we check anything as far as validity for caa-domains?
 
     @staticmethod
     def validate_dcv_check_request_details(request_body, request_body_validation_issues) -> None:
         if 'validation-method' not in request_body:
-            request_body_validation_issues.append('missing-validation-method')
+            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_VALIDATION_METHOD))
         elif request_body['validation-method'] not in iter(DcvValidationMethod):
-            request_body_validation_issues.append('invalid-validation-method')
+            bad_validation_method = request_body['validation-method']
+            request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_VALIDATION_METHOD, bad_validation_method))
         else:
             if 'validation-details' not in request_body:  # TODO should we enforce this for all methods?
-                request_body_validation_issues.append('missing-validation-details')
+                request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_VALIDATION_DETAILS))
             else:
                 validation_details = request_body['validation-details']
                 # TODO should we enforce expected_challenge everywhere? or is it not actually required?
                 match request_body['validation-method']:
                     case DcvValidationMethod.DNS_GENERIC:
                         if 'prefix' not in validation_details:
-                            request_body_validation_issues.append('missing-prefix-in-validation-details')
+                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_PREFIX, DcvValidationMethod.DNS_GENERIC))
                         if 'record-type' not in validation_details:
-                            request_body_validation_issues.append('missing-record-type-in-validation-details')
+                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_RECORD_TYPE, DcvValidationMethod.DNS_GENERIC))
                         if 'expected-challenge' not in validation_details:
-                            request_body_validation_issues.append('missing-expected-challenge-in-validation-details')
+                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_EXPECTED_CHALLENGE, DcvValidationMethod.DNS_GENERIC))
                     case DcvValidationMethod.HTTP_GENERIC:
                         if 'path' not in validation_details:
-                            request_body_validation_issues.append('missing-path-in-validation-details')
+                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_PATH, DcvValidationMethod.HTTP_GENERIC))
                         if 'expected-challenge' not in validation_details:
-                            request_body_validation_issues.append('missing-expected-challenge-in-validation-details')
+                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_EXPECTED_CHALLENGE, DcvValidationMethod.HTTP_GENERIC))
                     case DcvValidationMethod.TLS_USING_ALPN:
                         if 'expected-challenge' not in validation_details:
-                            request_body_validation_issues.append('missing-expected-challenge-in-validation-details')
+                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_EXPECTED_CHALLENGE, DcvValidationMethod.TLS_USING_ALPN))
 
     @staticmethod
     def validate_api_version(api_version, request_body_validation_issues) -> None:
@@ -94,3 +99,15 @@ class MpicRequestValidator:
             request_api_major_version = api_version.split('.')
             if int(request_api_major_version[0]) != 1:
                 request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_API_VERSION, api_version))
+
+    @staticmethod
+    def validate_requested_perspectives(requested_perspectives, known_perspectives, request_body_validation_issues) -> None:
+        # check if requested_perspectives is a subset of known_perspectives
+        if not all(perspective in known_perspectives for perspective in requested_perspectives):
+            request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_PERSPECTIVE_LIST))
+
+    @staticmethod
+    def validate_requested_perspective_count(requested_perspective_count, known_perspectives, request_body_validation_issues) -> None:
+        # check if requested_perspective_count is an integer, at least 2, and at most the number of known_perspectives
+        if not (isinstance(requested_perspective_count, int) and 2 <= requested_perspective_count <= len(known_perspectives)):
+            request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_PERSPECTIVE_COUNT, requested_perspective_count))

--- a/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
@@ -1,117 +1,119 @@
-import numbers
 import re
+
+from aws_lambda_python.mpic_coordinator.config.service_config import API_VERSION
 from aws_lambda_python.mpic_coordinator.domain.certificate_type import CertificateType
 from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvValidationMethod
-from aws_lambda_python.mpic_coordinator.domain.request_paths import RequestPaths
+from aws_lambda_python.mpic_coordinator.domain.request_path import RequestPath
 from aws_lambda_python.mpic_coordinator.messages.validation_messages import ValidationMessages
 from aws_lambda_python.mpic_coordinator.validation_issue import ValidationIssue
 
 
 class MpicRequestValidator:
     @staticmethod
-    # returns a list of validation issues found in the request body; if empty, request body is valid
+    # returns a list of validation issues found in the request; if empty, request is (probably) valid
     # TODO return upon finding first validation issue? or accumulate issues? accumulating is more "helpful" to caller
-    def is_request_body_valid(request_path, request_body, known_perspectives) -> (bool, list):
-        request_body_validation_issues = []
+    def is_request_valid(request_path, request_body, known_perspectives) -> (bool, list):
+        request_validation_issues = []
 
         # enforce presence of required fields
         if 'api-version' not in request_body:
-            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_API_VERSION))
+            request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_API_VERSION))
         else:
-            MpicRequestValidator.validate_api_version(request_body['api-version'], request_body_validation_issues)
+            MpicRequestValidator.validate_api_version(request_body['api-version'], request_validation_issues)
 
         if 'system-params' not in request_body:
-            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_SYSTEM_PARAMS))
+            request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_SYSTEM_PARAMS))
         else:  # TODO rename 'identifier' to something more descriptive in the spec, then fix this error message
             if 'identifier' not in request_body['system-params']:
-                request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_DOMAIN_OR_IP_TARGET))
+                request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_DOMAIN_OR_IP_TARGET))
 
             # enforce that only one of 'perspectives' or 'perspective-count' is present
             if 'perspectives' in request_body['system-params'] and 'perspective-count' in request_body['system-params']:
-                request_body_validation_issues.append(ValidationIssue(ValidationMessages.PERSPECTIVES_WITH_PERSPECTIVE_COUNT))
+                request_validation_issues.append(ValidationIssue(ValidationMessages.PERSPECTIVES_WITH_PERSPECTIVE_COUNT))
             elif 'perspectives' in request_body['system-params']:
                 requested_perspectives = request_body['system-params']['perspectives']
-                MpicRequestValidator.validate_requested_perspectives(requested_perspectives, known_perspectives, request_body_validation_issues)
+                MpicRequestValidator.validate_requested_perspectives(requested_perspectives, known_perspectives, request_validation_issues)
             elif 'perspective-count' in request_body['system-params']:
                 requested_perspective_count = request_body['system-params']['perspective-count']
-                MpicRequestValidator.validate_requested_perspective_count(requested_perspective_count, known_perspectives, request_body_validation_issues)
+                MpicRequestValidator.validate_requested_perspective_count(requested_perspective_count, known_perspectives, request_validation_issues)
 
         # enforce additional validation rules based on request path
         match request_path:
-            case RequestPaths.CAA_CHECK:
+            case RequestPath.CAA_CHECK:
                 if 'caa-details' in request_body:
-                    MpicRequestValidator.validate_caa_check_request_details(request_body, request_body_validation_issues)
-            case RequestPaths.DCV_CHECK:
-                MpicRequestValidator.validate_dcv_check_request_details(request_body, request_body_validation_issues)
-            case RequestPaths.DCV_WITH_CAA_CHECK:
+                    MpicRequestValidator.validate_caa_check_request_details(request_body, request_validation_issues)
+            case RequestPath.DCV_CHECK:
+                MpicRequestValidator.validate_dcv_check_request_details(request_body, request_validation_issues)
+            case RequestPath.DCV_WITH_CAA_CHECK:
                 if 'caa-details' in request_body:
-                    MpicRequestValidator.validate_caa_check_request_details(request_body, request_body_validation_issues)
-                MpicRequestValidator.validate_dcv_check_request_details(request_body, request_body_validation_issues)
+                    MpicRequestValidator.validate_caa_check_request_details(request_body, request_validation_issues)
+                MpicRequestValidator.validate_dcv_check_request_details(request_body, request_validation_issues)
             case _:
-                request_body_validation_issues.append(ValidationIssue(ValidationMessages.UNSUPPORTED_REQUEST_PATH, request_path))
+                request_validation_issues.append(ValidationIssue(ValidationMessages.UNSUPPORTED_REQUEST_PATH, request_path))
 
         # returns true if no validation issues found, false otherwise; includes list of validation issues found
-        return len(request_body_validation_issues) == 0, request_body_validation_issues
+        return len(request_validation_issues) == 0, request_validation_issues
 
     @staticmethod
-    def validate_caa_check_request_details(request_body, request_body_validation_issues) -> None:
+    def validate_caa_check_request_details(request_body, request_validation_issues) -> None:
         if 'caa-details' in request_body:
             if 'certificate-type' in request_body['caa-details']:
                 certificate_type = request_body['caa-details']['certificate-type']
                 # check if certificate_type is not in CertificateType enum
                 if certificate_type not in iter(CertificateType):
-                    request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_CERTIFICATE_TYPE, certificate_type))
+                    request_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_CERTIFICATE_TYPE, certificate_type))
                 # TODO do we check anything as far as validity for caa-domains?
 
     @staticmethod
-    def validate_dcv_check_request_details(request_body, request_body_validation_issues) -> None:
+    def validate_dcv_check_request_details(request_body, request_validation_issues) -> None:
         if 'validation-method' not in request_body:
-            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_VALIDATION_METHOD))
+            request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_VALIDATION_METHOD))
         elif request_body['validation-method'] not in iter(DcvValidationMethod):
             bad_validation_method = request_body['validation-method']
-            request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_VALIDATION_METHOD, bad_validation_method))
+            request_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_VALIDATION_METHOD, bad_validation_method))
         else:
             if 'validation-details' not in request_body:  # TODO should we enforce this for all methods?
-                request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_VALIDATION_DETAILS))
+                request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_VALIDATION_DETAILS))
             else:
                 validation_details = request_body['validation-details']
                 # TODO should we enforce expected_challenge everywhere? or is it not actually required?
                 match request_body['validation-method']:
                     case DcvValidationMethod.DNS_GENERIC:
                         if 'prefix' not in validation_details:
-                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_PREFIX, DcvValidationMethod.DNS_GENERIC))
+                            request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_PREFIX, DcvValidationMethod.DNS_GENERIC))
                         if 'record-type' not in validation_details:
-                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_RECORD_TYPE, DcvValidationMethod.DNS_GENERIC))
+                            request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_RECORD_TYPE, DcvValidationMethod.DNS_GENERIC))
                         if 'expected-challenge' not in validation_details:
-                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_EXPECTED_CHALLENGE, DcvValidationMethod.DNS_GENERIC))
+                            request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_EXPECTED_CHALLENGE, DcvValidationMethod.DNS_GENERIC))
                     case DcvValidationMethod.HTTP_GENERIC:
                         if 'path' not in validation_details:
-                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_PATH, DcvValidationMethod.HTTP_GENERIC))
+                            request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_PATH, DcvValidationMethod.HTTP_GENERIC))
                         if 'expected-challenge' not in validation_details:
-                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_EXPECTED_CHALLENGE, DcvValidationMethod.HTTP_GENERIC))
+                            request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_EXPECTED_CHALLENGE, DcvValidationMethod.HTTP_GENERIC))
                     case DcvValidationMethod.TLS_USING_ALPN:
                         if 'expected-challenge' not in validation_details:
-                            request_body_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_EXPECTED_CHALLENGE, DcvValidationMethod.TLS_USING_ALPN))
+                            request_validation_issues.append(ValidationIssue(ValidationMessages.MISSING_EXPECTED_CHALLENGE, DcvValidationMethod.TLS_USING_ALPN))
 
     @staticmethod
-    def validate_api_version(api_version, request_body_validation_issues) -> None:
+    def validate_api_version(api_version, request_validation_issues) -> None:
         # follow SemVer guidelines: https://semver.org/ (major version, minor version, patch version)
         # check if api_version matches regex pattern for API versions that look like 1.0.0
         if not re.match(r'^\d+(\.\d+)+$', api_version):
-            request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_API_VERSION, api_version))
+            request_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_API_VERSION, api_version))
         else:
-            request_api_major_version = api_version.split('.')
-            if int(request_api_major_version[0]) != 1:  # check if major version is 1; ignore minor and patch versions
-                request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_API_VERSION, api_version))
+            current_api_major_version = API_VERSION.split('.')[0]
+            request_api_major_version = api_version.split('.')[0]
+            if int(request_api_major_version) != int(current_api_major_version):  # check if major version is 1; ignore minor and patch versions
+                request_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_API_VERSION, api_version))
 
     @staticmethod
-    def validate_requested_perspectives(requested_perspectives, known_perspectives, request_body_validation_issues) -> None:
+    def validate_requested_perspectives(requested_perspectives, known_perspectives, request_validation_issues) -> None:
         # check if requested_perspectives is a subset of known_perspectives
         if not all(perspective in known_perspectives for perspective in requested_perspectives):
-            request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_PERSPECTIVE_LIST))
+            request_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_PERSPECTIVE_LIST))
 
     @staticmethod
-    def validate_requested_perspective_count(requested_perspective_count, known_perspectives, request_body_validation_issues) -> None:
+    def validate_requested_perspective_count(requested_perspective_count, known_perspectives, request_validation_issues) -> None:
         # check if requested_perspective_count is an integer, at least 2, and at most the number of known_perspectives
         if not (isinstance(requested_perspective_count, int) and 2 <= requested_perspective_count <= len(known_perspectives)):
-            request_body_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_PERSPECTIVE_COUNT, requested_perspective_count))
+            request_validation_issues.append(ValidationIssue(ValidationMessages.INVALID_PERSPECTIVE_COUNT, requested_perspective_count))

--- a/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_request_validator.py
@@ -3,9 +3,9 @@ from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvV
 
 
 class MpicRequestValidator:
-    @staticmethod  # placeholder for future validation of request body
-    #  returns a list of validation issues found in the request body; if empty, request body is valid
-    def validate_request_body(request_path, request_body):
+    @staticmethod
+    # returns a list of validation issues found in the request body; if empty, request body is valid
+    def is_request_body_valid(request_path, request_body):
         request_body_validation_issues = []
 
         # enforce presence of required fields
@@ -38,10 +38,10 @@ class MpicRequestValidator:
     @staticmethod
     def validate_caa_check_request_details(request_body, request_body_validation_issues) -> None:
         if 'caa-details' in request_body:
+            # TODO is there a default certificate type we should use if not specified? (then field _can_ be missing)
             if 'certificate-type' not in request_body['caa-details']:
                 request_body_validation_issues.append('missing-certificate-type-in-caa-details')
             else:
-                # TODO is there a default certificate type we should use if not specified?
                 certificate_type = request_body['caa-details']['certificate-type']
                 # check if certificate_type is not in CertificateType enum
                 if certificate_type not in iter(CertificateType):

--- a/src/aws_lambda_python/mpic_coordinator/mpic_response_builder.py
+++ b/src/aws_lambda_python/mpic_coordinator/mpic_response_builder.py
@@ -1,11 +1,43 @@
 import json
 
+from aws_lambda_python.mpic_coordinator.config.service_config import API_VERSION
+from aws_lambda_python.mpic_coordinator.domain.check_type import CheckType
+from aws_lambda_python.mpic_coordinator.domain.request_path import RequestPath
+
 
 class MpicResponseBuilder:
-    # FIXME: This method is expected to be implemented in the future
     @staticmethod
-    def build_response(status_code, response_body):
+    def build_response(request_path, request_body, perspective_count, quorum_count, perspective_responses_per_check_type, valid_by_check_type):
+        system_params = request_body['system-params'] if 'system-params' in request_body else None
+        validation_details = request_body['validation-details'] if 'validation-details' in request_body else None
+        validation_method = request_body['validation-method'] if 'validation-method' in request_body else None
+
+        response_body = {
+            'api-version': API_VERSION,
+            'request-system-params': system_params,  # TODO rename this field in API
+            'number-of-perspectives-used': perspective_count,  # TODO add this field to API
+            'required-quorum-count-used': quorum_count,  # TODO add this field to API
+        }
+
+        match request_path:
+            case RequestPath.CAA_CHECK:
+                response_body['perspectives'] = perspective_responses_per_check_type[CheckType.CAA]
+                response_body['is-valid'] = valid_by_check_type[CheckType.CAA]
+            case RequestPath.DCV_CHECK:
+                response_body['perspectives'] = perspective_responses_per_check_type[CheckType.DCV]
+                response_body['validation-details'] = validation_details
+                response_body['validation-method'] = validation_method
+                response_body['is-valid'] = valid_by_check_type[CheckType.DCV]
+            case RequestPath.DCV_WITH_CAA_CHECK:
+                response_body['perspectives-dcv'] = perspective_responses_per_check_type[CheckType.DCV]
+                response_body['perspectives-caa'] = perspective_responses_per_check_type[CheckType.CAA]
+                response_body['validation-details'] = validation_details
+                response_body['validation-method'] = validation_method
+                response_body['is-valid-dcv'] = valid_by_check_type[CheckType.DCV]
+                response_body['is-valid-caa'] = valid_by_check_type[CheckType.CAA]
+                response_body['is-valid'] = response_body['is-valid-dcv'] and response_body['is-valid-caa']
+
         return {
-            'statusCode': status_code,
+            'statusCode': 200,  # other status codes will be returned earlier in the Coordinator logic
             'body': json.dumps(response_body)
         }

--- a/src/aws_lambda_python/mpic_coordinator/validation_issue.py
+++ b/src/aws_lambda_python/mpic_coordinator/validation_issue.py
@@ -1,0 +1,4 @@
+class ValidationIssue:
+    def __init__(self, validation_message, *message_args):
+        self.issue_type = validation_message.key
+        self.message = validation_message.message.format(*message_args)

--- a/tests/integration/test_deployed_mpic_api.py
+++ b/tests/integration/test_deployed_mpic_api.py
@@ -2,16 +2,24 @@ import json
 import sys
 import pytest
 import testing_api_client
+from aws_lambda_python.mpic_coordinator.messages.validation_messages import ValidationMessages
 
 
 # noinspection PyMethodMayBeStatic
 @pytest.mark.integration
 class TestDeployedMpicApi:
-    def api_should_return_200_given_valid_authentication(self, monkeypatch):
-        monkeypatch.setattr(sys, 'argv', sys.argv[:1])  # blank out argv except for first param; arg parser doesn't expect pytest args
+    @pytest.fixture(scope='class')
+    def api_client(self):
+        with pytest.MonkeyPatch.context() as class_scoped_monkeypatch:
+            # blank out argv except first param; arg parser doesn't expect pytest args
+            class_scoped_monkeypatch.setattr(sys, 'argv', sys.argv[:1])
+            api_client = testing_api_client.TestingApiClient()
+            yield api_client
+            api_client.close()
+
+    def api_should_return_200_given_valid_authentication(self, api_client):
         perspective_count = 3
 
-        api_client = testing_api_client.TestingApiClient()
         body = {
             'api-version': '1.0.0',
             'system-params': {
@@ -26,7 +34,6 @@ class TestDeployedMpicApi:
             }
         }
         response = api_client.post('caa-check', json.dumps(body))
-        api_client.close()
         # response_body_as_json = response.json()
         assert response.status_code == 200
         # assert response body has a list of perspectives with length 2, and each element has response code 200
@@ -35,3 +42,26 @@ class TestDeployedMpicApi:
         # assert that each element in perspectives_list has a 'statusCode' element with value 200
         assert len(perspectives_list) == perspective_count
         assert len(list(filter(lambda perspective: perspective['statusCode'] == 200, perspectives_list))) == perspective_count
+
+    def api_should_return_400_given_invalid_parameters_in_request(self, api_client):
+        perspective_count = 3
+
+        body = {
+            'api-version': '1.0.0',
+            'system-params': {
+                'identifier': 'test',
+                'perspective-count': perspective_count,
+                'quorum-count': 5  # invalid quorum count
+            },
+            'caa-details': {
+                'caa-domains': [
+                    'mozilla.com'
+                ]
+            }
+        }
+        response = api_client.post('caa-check', json.dumps(body))
+        assert response.status_code == 400
+        response_body = json.loads(response.text)
+        assert response_body['error'] == ValidationMessages.REQUEST_VALIDATION_FAILED.key
+        assert any(issue['issue_type'] == ValidationMessages.INVALID_QUORUM_COUNT.key for issue in response_body['validation-issues'])
+        

--- a/tests/unit/test_mpic_coordinator.py
+++ b/tests/unit/test_mpic_coordinator.py
@@ -65,7 +65,6 @@ class TestMpicCoordinator:
             'api-version': API_VERSION,
             'system-params': {'identifier': 'test'},
         }
-        event = {'path': RequestPath.CAA_CHECK, 'body': json.dumps(body)}
         mpic_coordinator = MpicCoordinator()
         required_quorum_count = mpic_coordinator.determine_required_quorum_count(body['system-params'], requested_perspective_count)
         assert required_quorum_count == expected_quorum_size
@@ -75,7 +74,6 @@ class TestMpicCoordinator:
             'api-version': API_VERSION,
             'system-params': {'identifier': 'test', 'quorum-count': 5}
         }
-        event = {'path': RequestPath.CAA_CHECK, 'body': json.dumps(body)}
         mpic_coordinator = MpicCoordinator()
         required_quorum_count = mpic_coordinator.determine_required_quorum_count(body['system-params'], 6)
         assert required_quorum_count == 5

--- a/tests/unit/test_mpic_coordinator.py
+++ b/tests/unit/test_mpic_coordinator.py
@@ -40,6 +40,7 @@ class TestMpicCoordinator:
         with pytest.raises(ValueError):
             mpic_coordinator.random_select_perspectives_considering_rir(perspectives, 10, 'test_identifier')  # expect error
 
+    # TODO remove some of these validation tests once the request validator is complete; keep a couple to test proper integration
     def coordinate_mpic__should_return_error_given_failed_api_version_check(self, set_env_variables):
         body = {
             'api-version': '0.0.0',  # invalid version

--- a/tests/unit/test_mpic_coordinator.py
+++ b/tests/unit/test_mpic_coordinator.py
@@ -2,7 +2,9 @@ import json
 import pytest
 import os
 
-from aws_lambda_python.mpic_coordinator.domain.request_paths import RequestPaths
+from aws_lambda_python.mpic_coordinator.config.service_config import API_VERSION
+from aws_lambda_python.mpic_coordinator.domain.check_type import CheckType
+from aws_lambda_python.mpic_coordinator.domain.request_path import RequestPath
 from aws_lambda_python.mpic_coordinator.messages.validation_messages import ValidationMessages
 from aws_lambda_python.mpic_coordinator.mpic_coordinator import MpicCoordinator
 from valid_request_creator import ValidRequestCreator
@@ -29,27 +31,27 @@ class TestMpicCoordinator:
             yield class_scoped_monkeypatch  # restore the environment afterward
 
     @pytest.mark.parametrize('requested_perspective_count, expected_unique_rirs', [(2, 2), (3, 3), (4, 3)])
-    def random_select_perspectives_considering_rir__should_select_diverse_rirs_given_list_where_some_share_same_rir(
+    def select_random_perspectives_across_rirs__should_select_diverse_rirs_given_list_where_some_share_same_rir(
             self, set_env_variables, requested_perspective_count, expected_unique_rirs):
         perspectives = os.getenv('perspective_names').split('|')  # same split logic as in actual calling code
         mpic_coordinator = MpicCoordinator()
-        selected_perspectives = mpic_coordinator.random_select_perspectives_considering_rir(perspectives, requested_perspective_count, 'test_identifier')
+        selected_perspectives = mpic_coordinator.select_random_perspectives_across_rirs(perspectives, requested_perspective_count, 'test_identifier')
         assert len(set(map(lambda p: p.split('.')[0], selected_perspectives))) == expected_unique_rirs  # expect 3 unique rirs from setup data
 
-    def random_select_perspectives_considering_rir__should_throw_error_given_requested_count_exceeds_total_perspectives(
+    def select_random_perspectives_across_rirs__should_throw_error_given_requested_count_exceeds_total_perspectives(
             self, set_env_variables):
         perspectives = os.getenv('perspective_names').split('|')
         excessive_count = len(perspectives) + 1
         mpic_coordinator = MpicCoordinator()
         with pytest.raises(ValueError):
-            mpic_coordinator.random_select_perspectives_considering_rir(perspectives, excessive_count, 'test_identifier')  # expect error
+            mpic_coordinator.select_random_perspectives_across_rirs(perspectives, excessive_count, 'test_identifier')  # expect error
 
     @pytest.mark.parametrize('field_to_delete, error_message_to_find', [('api-version', ValidationMessages.MISSING_API_VERSION.key),
                                                                         ('system-params', ValidationMessages.MISSING_SYSTEM_PARAMS.key)])
     def coordinate_mpic__should_return_error_given_invalid_request_body(self, set_env_variables, field_to_delete, error_message_to_find):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body[field_to_delete]
-        event = {'path': '/caa-check', 'body': json.dumps(body)}
+        event = {'path': RequestPath.CAA_CHECK, 'body': json.dumps(body)}
         mpic_coordinator = MpicCoordinator()
         result = mpic_coordinator.coordinate_mpic(event)
         assert result['statusCode'] == 400
@@ -57,18 +59,17 @@ class TestMpicCoordinator:
         assert response_body['error'] == ValidationMessages.REQUEST_VALIDATION_FAILED.key
         assert any(issue['issue_type'] == error_message_to_find for issue in response_body['validation-issues'])
 
-    # FIXME: This test misbehaves for now because the code does not dynamically calculate required quorum size
     @pytest.mark.skip
     @pytest.mark.parametrize('requested_perspective_count, expected_quorum_size', [(4, 3), (5, 4), (6, 4)])
-    def coordinate_mpic__should_dynamically_set_required_quorum_count_given_no_quorum_specified(
+    def determine_required_quorum_count__should_dynamically_set_required_quorum_count_given_no_quorum_specified(
             self, set_env_variables, requested_perspective_count, expected_quorum_size):
         body = {
-            'api-version': '1.0.0',
-            'system-params': {'identifier': 'test', 'perspective-count': requested_perspective_count},
+            'api-version': API_VERSION,
+            'system-params': {'identifier': 'test'},
         }
-        event = {'path': '/caa-check', 'body': json.dumps(body)}
+        event = {'path': RequestPath.CAA_CHECK, 'body': json.dumps(body)}
         mpic_coordinator = MpicCoordinator()
-        result = mpic_coordinator.coordinate_mpic(event)
+        result = mpic_coordinator.determine_required_quorum_count(body['system-params'], requested_perspective_count)
         assert result['statusCode'] == 200
         assert 'required-quorum-count' in result['body']
         body_as_dict = json.loads(result['body'])
@@ -77,34 +78,44 @@ class TestMpicCoordinator:
 
     def collect_async_calls_to_issue__should_have_only_caa_calls_given_caa_check_request_path(self, set_env_variables):
         body = {
-            'api-version': '1.0.0',
+            'api-version': API_VERSION,
+            'system-params': {'identifier': 'test'}
+        }
+        perspectives_to_use = os.getenv('perspective_names').split('|')
+        mpic_coordinator = MpicCoordinator()
+        call_list = mpic_coordinator.collect_async_calls_to_issue(RequestPath.CAA_CHECK, body, perspectives_to_use)
+        assert len(call_list) == 6
+        assert set(map(lambda call_result: call_result.check_type, call_list)) == {CheckType.CAA}  # ensure each call is of type 'caa'
+
+    def collect_async_calls_to_issue__should_include_caa_details_as_caa_params_in_input_args_if_present(self, set_env_variables):
+        body = {
+            'api-version': API_VERSION,
             'system-params': {'identifier': 'test'},
             'caa-details': {'caa-domains': ['example.com']}
         }
         perspectives_to_use = os.getenv('perspective_names').split('|')
         mpic_coordinator = MpicCoordinator()
-        call_list = mpic_coordinator.collect_async_calls_to_issue(RequestPaths.CAA_CHECK, body, perspectives_to_use)
-        assert len(call_list) == 6
-        # ensure each call is of type 'caa'
-        assert set(map(lambda call_result: call_result.check_type, call_list)) == {'caa'}
+        call_list = mpic_coordinator.collect_async_calls_to_issue(RequestPath.CAA_CHECK, body, perspectives_to_use)
+        assert all(call.input_args['caa-params']['caa-domains'] == ['example.com'] for call in call_list)
 
-    def collect_async_calls_to_issue__should_have_only_dcv_calls_given_dcv_request_path(self, set_env_variables):
+    def collect_async_calls_to_issue__should_have_only_dcv_calls_and_include_validation_input_args_given_dcv_request_path(self, set_env_variables):
         body = {
-            'api-version': '1.0.0',
+            'api-version': API_VERSION,
             'system-params': {'identifier': 'test'},
             'validation-method': 'test-method',
             'validation-details': 'test-details'
         }
         perspectives_to_use = os.getenv('perspective_names').split('|')
         mpic_coordinator = MpicCoordinator()
-        call_list = mpic_coordinator.collect_async_calls_to_issue(RequestPaths.DCV_CHECK, body, perspectives_to_use)
+        call_list = mpic_coordinator.collect_async_calls_to_issue(RequestPath.DCV_CHECK, body, perspectives_to_use)
         assert len(call_list) == 6
-        # ensure each call is of type 'dcv'
-        assert set(map(lambda call_result: call_result.check_type, call_list)) == {'dcv'}
+        assert set(map(lambda call_result: call_result.check_type, call_list)) == {CheckType.DCV}  # ensure each call is of type 'dcv'
+        assert all(call.input_args['validation-method'] == 'test-method' for call in call_list)
+        assert all(call.input_args['validation-params'] == 'test-details' for call in call_list)
 
     def collect_async_calls_to_issue__should_have_caa_and_dcv_calls_given_dcv_with_caa_request_path(self, set_env_variables):
         body = {
-            'api-version': '1.0.0',
+            'api-version': API_VERSION,
             'system-params': {'identifier': 'test'},
             'caa-details': {'caa-domains': ['example.com']},
             'validation-method': 'test-method',
@@ -112,20 +123,20 @@ class TestMpicCoordinator:
         }
         perspectives_to_use = os.getenv('perspective_names').split('|')
         mpic_coordinator = MpicCoordinator()
-        call_list = mpic_coordinator.collect_async_calls_to_issue(RequestPaths.DCV_WITH_CAA_CHECK, body, perspectives_to_use)
+        call_list = mpic_coordinator.collect_async_calls_to_issue(RequestPath.DCV_WITH_CAA_CHECK, body, perspectives_to_use)
         assert len(call_list) == 12
         # ensure the list contains both 'caa' and 'dcv' calls
-        assert set(map(lambda call_result: call_result.check_type, call_list)) == {'caa', 'dcv'}
+        assert set(map(lambda call_result: call_result.check_type, call_list)) == {CheckType.CAA, CheckType.DCV}
 
     @pytest.mark.skip  # FIXME: this test isn't ready; there is no way to easily inspect caa domains used
     def collect_async_calls_to_issue__should_use_default_caa_domains_if_none_specified(self, set_env_variables):
         body = {
-            'api-version': '1.0.0',
+            'api-version': API_VERSION,
             'system-params': {'identifier': 'test'}
         }
         perspectives_to_use = os.getenv('perspective_names').split('|')
         mpic_coordinator = MpicCoordinator()
-        mpic_coordinator.collect_async_calls_to_issue('/caa-check', body, perspectives_to_use)
+        mpic_coordinator.collect_async_calls_to_issue(RequestPath.CAA_CHECK, body, perspectives_to_use)
         # ensure each call has the default caa domains
         assert False
 

--- a/tests/unit/test_mpic_coordinator.py
+++ b/tests/unit/test_mpic_coordinator.py
@@ -20,7 +20,6 @@ class TestMpicCoordinator:
             'validator_arns': 'arn:aws:acm-pca:us-east-1:123456789012:validator/rir1.region1a|arn:aws:acm-pca:us-east-1:123456789012:validator/rir1.region1b|arn:aws:acm-pca:us-east-1:123456789012:validator/rir2.region2a|arn:aws:acm-pca:us-east-1:123456789012:validator/rir2.region2b|arn:aws:acm-pca:us-east-1:123456789012:validator/rir3.region3a|arn:aws:acm-pca:us-east-1:123456789012:validator/rir3.region3b',
             'caa_arns': 'arn:aws:acm-pca:us-east-1:123456789012:caa/rir1.region1a|arn:aws:acm-pca:us-east-1:123456789012:caa/rir1.region1b|arn:aws:acm-pca:us-east-1:123456789012:caa/rir2.region2a|arn:aws:acm-pca:us-east-1:123456789012:caa/rir2.region2b|arn:aws:acm-pca:us-east-1:123456789012:caa/rir3.region3a|arn:aws:acm-pca:us-east-1:123456789012:caa/rir3.region3b',
             'default_perspective_count': '3',
-            'default_quorum': '2',
             'enforce_distinct_rir_regions': '1',
             'hash_secret': 'test_secret',
             'caa_domains': 'example.com|example.net|example.org'

--- a/tests/unit/test_mpic_request_validator.py
+++ b/tests/unit/test_mpic_request_validator.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvValidationMethod
@@ -10,7 +12,7 @@ class TestMpicRequestValidator:
     def __create_valid_caa_check_request(self):
         return {
             'api-version': '1.0.0',
-            'system-params': {'identifier': 'test'},
+            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
             'caa-details': {'certificate-type': 'tls-server'}
         }
 
@@ -25,116 +27,136 @@ class TestMpicRequestValidator:
                 validation_details = {'expected-challenge': 'test'}
         return {
             'api-version': '1.0.0',
-            'system-params': {'identifier': 'test'},
+            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
             'validation-method': validation_method,
             'validation-details': validation_details
         }
 
-    def validate_request_body__should_return_true_and_empty_message_list_given_valid_caa_check_request(self):
+    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request(self):
         body = self.__create_valid_caa_check_request()
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/caa-check', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
         assert is_body_valid is True
         assert len(body_validation_issues) == 0
 
-    def validate_request_body__should_return_true_and_empty_message_list_given_valid_dcv_check_request(self):
-        body = self.__create_valid_dcv_check_request()
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/validation', body)
+    @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_GENERIC, DcvValidationMethod.HTTP_GENERIC,
+                                                   DcvValidationMethod.TLS_USING_ALPN])
+    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_dcv_check_request(self, validation_method):
+        body = self.__create_valid_dcv_check_request(validation_method)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
         assert is_body_valid is True
         assert len(body_validation_issues) == 0
 
-    def validate_request_body__should_return_false_and_message_given_missing_api_version(self):
+    def is_request_body_valid__should_return_false_and_message_given_missing_api_version(self):
         body = self.__create_valid_caa_check_request()
         del body['api-version']  # remove api-version field
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/caa-check', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
         assert is_body_valid is False
         assert 'missing-api-version' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_missing_system_params(self):
+    def is_request_body_valid__should_return_false_and_message_given_missing_system_params(self):
         body = self.__create_valid_caa_check_request()
         del body['system-params']  # remove system-params field
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/caa-check', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
         assert is_body_valid is False
         assert 'missing-system-params' in body_validation_issues
 
-    # TODO rename when you rename identifier field in the spec
-    def validate_request_body__should_return_false_and_message_given_missing_identifier(self):
+    # TODO rename when you rename identifier field in the spec (recommend "domain_or_ip_target" for highest clarity)
+    def is_request_body_valid__should_return_false_and_message_given_missing_identifier(self):
         body = self.__create_valid_caa_check_request()
         del body['system-params']['identifier']  # remove identifier field
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/caa-check', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
         assert is_body_valid is False
         assert 'missing-domain-or-ip-target' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_both_perspective_and_perspective_count_present(self):
+    def is_request_body_valid__should_return_false_and_message_given_both_perspective_and_perspective_count_present(self):
         body = self.__create_valid_caa_check_request()
         body['system-params']['perspectives'] = ['perspective1', 'perspective2']
         body['system-params']['perspective-count'] = 2
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/caa-check', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
         assert is_body_valid is False
         assert 'contains-both-perspectives-and-perspective-count' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_missing_certificate_type_for_caa_check(self):
+    @pytest.mark.xfail  # TODO enable test when validation logic for perspective count is implemented
+    @pytest.mark.parametrize('perspective_count', [1, 0, -1, 'abc', sys.maxsize+1])
+    def is_request_body_valid__should_return_false_and_message_given_invalid_perspective_count(self, perspective_count):
+        body = self.__create_valid_caa_check_request()
+        body['system-params']['perspective-count'] = perspective_count
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        assert is_body_valid is False
+        assert 'invalid-perspective-count' in body_validation_issues
+
+    @pytest.mark.xfail  # TODO enable test when validation logic for quorum count is implemented
+    @pytest.mark.parametrize('quorum_count', [1, 0, -1, 10, 'abc', sys.maxsize+1])
+    def is_request_body_valid__should_return_false_and_message_given_invalid_quorum_count(self, quorum_count):
+        body = self.__create_valid_caa_check_request()
+        body['system-params']['quorum'] = quorum_count
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        assert is_body_valid is False
+        assert 'invalid-quorum-count' in body_validation_issues
+
+    def is_request_body_valid__should_return_false_and_message_given_missing_certificate_type_for_caa_check(self):
         body = self.__create_valid_caa_check_request()
         del body['caa-details']['certificate-type']
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/caa-check', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
         assert is_body_valid is False
         assert 'missing-certificate-type-in-caa-details' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_invalid_certificate_type_specified(self):
+    def is_request_body_valid__should_return_false_and_message_given_invalid_certificate_type_specified(self):
         body = self.__create_valid_caa_check_request()
         body['caa-details']['certificate-type'] = 'invalid-certificate-type'
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/caa-check', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
         assert is_body_valid is False
         assert 'invalid-certificate-type-in-caa-details' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_missing_validation_method_for_dcv(self):
+    def is_request_body_valid__should_return_false_and_message_given_missing_validation_method_for_dcv(self):
         body = self.__create_valid_dcv_check_request()
         del body['validation-method']
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/validation', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
         assert is_body_valid is False
         assert 'missing-validation-method' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_invalid_validation_method_specified(self):
+    def is_request_body_valid__should_return_false_and_message_given_invalid_validation_method_specified(self):
         body = self.__create_valid_dcv_check_request()
         # noinspection PyTypedDict
         body['validation-method'] = 'invalid-validation-method'
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/validation', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
         assert is_body_valid is False
         assert 'invalid-validation-method' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_missing_validation_details_for_dcv(self):
+    def is_request_body_valid__should_return_false_and_message_given_missing_validation_details_for_dcv(self):
         body = self.__create_valid_dcv_check_request()
         del body['validation-details']
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/validation', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
         assert is_body_valid is False
         assert 'missing-validation-details' in body_validation_issues
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_GENERIC, DcvValidationMethod.HTTP_GENERIC,
                                                    DcvValidationMethod.TLS_USING_ALPN])
-    def validate_request_body__should_return_false_and_message_given_missing_expected_challenge_for_dcv(self, validation_method):
+    def is_request_body_valid__should_return_false_and_message_given_missing_expected_challenge_for_dcv(self, validation_method):
         body = self.__create_valid_dcv_check_request(validation_method)
         del body['validation-details']['expected-challenge']
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/validation', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
         assert is_body_valid is False
         assert 'missing-expected-challenge-in-validation-details' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_missing_prefix_for_dns_validation(self):
+    def is_request_body_valid__should_return_false_and_message_given_missing_prefix_for_dns_validation(self):
         body = self.__create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
         del body['validation-details']['prefix']
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/validation', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
         assert is_body_valid is False
         assert 'missing-prefix-in-validation-details' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_missing_record_type_for_dns_validation(self):
+    def is_request_body_valid__should_return_false_and_message_given_missing_record_type_for_dns_validation(self):
         body = self.__create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
         del body['validation-details']['record-type']
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/validation', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
         assert is_body_valid is False
         assert 'missing-record-type-in-validation-details' in body_validation_issues
 
-    def validate_request_body__should_return_false_and_message_given_missing_path_for_http_validation(self):
+    def is_request_body_valid__should_return_false_and_message_given_missing_path_for_http_validation(self):
         body = self.__create_valid_dcv_check_request(DcvValidationMethod.HTTP_GENERIC)
         del body['validation-details']['path']
-        is_body_valid, body_validation_issues = MpicRequestValidator.validate_request_body('/validation', body)
+        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
         assert is_body_valid is False
         assert 'missing-path-in-validation-details' in body_validation_issues
 

--- a/tests/unit/test_mpic_request_validator.py
+++ b/tests/unit/test_mpic_request_validator.py
@@ -22,7 +22,7 @@ class TestMpicRequestValidator:
 
     def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request_with_perspective_list(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
-        body['system-params']['perspectives'] = '|'.join(self.known_perspectives[:6])
+        body['system-params']['perspectives'] = self.known_perspectives[:6]
         del body['system-params']['perspective-count']
         is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is True
@@ -79,7 +79,7 @@ class TestMpicRequestValidator:
 
     def is_request_body_valid__should_return_false_and_message_given_both_perspective_and_perspective_count_present(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
-        body['system-params']['perspectives'] = '|'.join(self.known_perspectives[:6])
+        body['system-params']['perspectives'] = self.known_perspectives[:6]
         body['system-params']['perspective-count'] = 2
         is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
@@ -98,7 +98,7 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_invalid_perspective_list(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['system-params']['perspective-count']
-        body['system-params']['perspectives'] = 'bad_p1|bad_p2|bad_p3|bad_p4|bad_p5|bad_p6'
+        body['system-params']['perspectives'] = ['bad_p1', 'bad_p2', 'bad_p3', 'bad_p4', 'bad_p5', 'bad_p6']
         is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.INVALID_PERSPECTIVE_LIST.key in [issue.issue_type for issue in validation_issues]

--- a/tests/unit/test_mpic_request_validator.py
+++ b/tests/unit/test_mpic_request_validator.py
@@ -110,16 +110,22 @@ class TestMpicRequestValidator:
         assert is_request_valid is False
         assert ValidationMessages.INVALID_PERSPECTIVE_LIST.key in [issue.issue_type for issue in validation_issues]
 
-    @pytest.mark.xfail  # TODO enable test when validation logic for quorum count is implemented
-    @pytest.mark.parametrize('quorum_count', [1, 0, -1, 10, 'abc', sys.maxsize+1])
+    @pytest.mark.parametrize('quorum_count', [1, -1, 10, 'abc', sys.maxsize+1])
     def is_request_valid__should_return_false_and_message_given_invalid_quorum_count(self, quorum_count):
         body = ValidRequestCreator.create_valid_caa_check_request()
-        body['system-params']['quorum'] = quorum_count
+        body['system-params']['quorum-count'] = quorum_count
         is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
         assert is_request_valid is False
         assert ValidationMessages.INVALID_QUORUM_COUNT.key in [issue.issue_type for issue in validation_issues]
         invalid_quorum_count_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_QUORUM_COUNT.key)
         assert str(quorum_count) in invalid_quorum_count_issue.message
+
+    def is_request_valid__should_allow_quorum_count_of_zero(self):
+        body = ValidRequestCreator.create_valid_caa_check_request()
+        body['system-params']['quorum-count'] = 0
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is True
+        assert len(validation_issues) == 0
 
     def is_request_valid__should_return_false_and_message_given_invalid_certificate_type_specified(self):
         body = ValidRequestCreator.create_valid_caa_check_request()

--- a/tests/unit/test_mpic_request_validator.py
+++ b/tests/unit/test_mpic_request_validator.py
@@ -3,7 +3,7 @@ import sys
 import pytest
 
 from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvValidationMethod
-from aws_lambda_python.mpic_coordinator.domain.request_paths import RequestPaths
+from aws_lambda_python.mpic_coordinator.domain.request_path import RequestPath
 from aws_lambda_python.mpic_coordinator.messages.validation_messages import ValidationMessages
 from aws_lambda_python.mpic_coordinator.mpic_request_validator import MpicRequestValidator
 from valid_request_creator import ValidRequestCreator
@@ -15,181 +15,181 @@ class TestMpicRequestValidator:
     def setup_class(cls):
         cls.known_perspectives = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10']
 
-    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request_with_perspective_count(self):
+    def is_request_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request_with_perspective_count(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is True
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is True
         assert len(validation_issues) == 0
 
-    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request_with_perspective_list(self):
+    def is_request_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request_with_perspective_list(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['perspectives'] = self.known_perspectives[:6]
         del body['system-params']['perspective-count']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is True
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is True
         assert len(validation_issues) == 0
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_GENERIC, DcvValidationMethod.HTTP_GENERIC,
                                                    DcvValidationMethod.TLS_USING_ALPN])
-    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_dcv_check_request(self, validation_method):
+    def is_request_valid__should_return_true_and_empty_message_list_given_valid_dcv_check_request(self, validation_method):
         body = ValidRequestCreator.create_valid_dcv_check_request(validation_method)
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
-        assert is_body_valid is True
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.DCV_CHECK, body, self.known_perspectives)
+        assert is_request_valid is True
         assert len(validation_issues) == 0
 
-    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_dcv_with_caa_check_request(self):
+    def is_request_valid__should_return_true_and_empty_message_list_given_valid_dcv_with_caa_check_request(self):
         body = ValidRequestCreator.create_valid_dcv_with_caa_check_request()
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_WITH_CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is True
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.DCV_WITH_CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is True
         assert len(validation_issues) == 0
 
-    def is_request_body_valid__should_return_false_and_message_given_missing_api_version(self):
+    def is_request_valid__should_return_false_and_message_given_missing_api_version(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['api-version']  # remove api-version field
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.MISSING_API_VERSION.key in [issue.issue_type for issue in validation_issues]
 
     @pytest.mark.parametrize('api_version', ['0.0.1', '5.0.0', '1;0;0', '1.', '100', 'bad-api-version'])  # ~=1.0.0 is valid
-    def is_request_body_valid__should_return_false_and_message_given_invalid_api_version(self, api_version):
+    def is_request_valid__should_return_false_and_message_given_invalid_api_version(self, api_version):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['api-version'] = api_version
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.INVALID_API_VERSION.key in [issue.issue_type for issue in validation_issues]
         invalid_api_version_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_API_VERSION.key)
         assert api_version in invalid_api_version_issue.message
 
     @pytest.mark.parametrize('request_path', ['/invalid-path'])  # do any other path types need testing?
-    def is_request_body_valid__should_return_false_and_message_given_unsupported_request_path(self, request_path):
+    def is_request_valid__should_return_false_and_message_given_unsupported_request_path(self, request_path):
         body = ValidRequestCreator.create_valid_caa_check_request()
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(request_path, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(request_path, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.UNSUPPORTED_REQUEST_PATH.key in [issue.issue_type for issue in validation_issues]
         unsupported_request_path_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.UNSUPPORTED_REQUEST_PATH.key)
         assert request_path in unsupported_request_path_issue.message
 
-    def is_request_body_valid__should_return_false_and_message_given_missing_system_params(self):
+    def is_request_valid__should_return_false_and_message_given_missing_system_params(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['system-params']  # remove system-params field
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.MISSING_SYSTEM_PARAMS.key in [issue.issue_type for issue in validation_issues]
 
     # TODO rename when you rename identifier field in the spec (recommend "domain_or_ip_target" for highest clarity)
-    def is_request_body_valid__should_return_false_and_message_given_missing_identifier(self):
+    def is_request_valid__should_return_false_and_message_given_missing_identifier(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['system-params']['identifier']  # remove identifier field
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.MISSING_DOMAIN_OR_IP_TARGET.key in [issue.issue_type for issue in validation_issues]
 
-    def is_request_body_valid__should_return_false_and_message_given_both_perspective_and_perspective_count_present(self):
+    def is_request_valid__should_return_false_and_message_given_both_perspective_and_perspective_count_present(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['perspectives'] = self.known_perspectives[:6]
         body['system-params']['perspective-count'] = 2
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.PERSPECTIVES_WITH_PERSPECTIVE_COUNT.key in [issue.issue_type for issue in validation_issues]
 
     @pytest.mark.parametrize('perspective_count', [1, 0, -1, 'abc', sys.maxsize+1])
-    def is_request_body_valid__should_return_false_and_message_given_invalid_perspective_count(self, perspective_count):
+    def is_request_valid__should_return_false_and_message_given_invalid_perspective_count(self, perspective_count):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['perspective-count'] = perspective_count
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.INVALID_PERSPECTIVE_COUNT.key in [issue.issue_type for issue in validation_issues]
         invalid_perspective_count_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_PERSPECTIVE_COUNT.key)
         assert str(perspective_count) in invalid_perspective_count_issue.message
 
-    def is_request_body_valid__should_return_false_and_message_given_invalid_perspective_list(self):
+    def is_request_valid__should_return_false_and_message_given_invalid_perspective_list(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['system-params']['perspective-count']
         body['system-params']['perspectives'] = ['bad_p1', 'bad_p2', 'bad_p3', 'bad_p4', 'bad_p5', 'bad_p6']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.INVALID_PERSPECTIVE_LIST.key in [issue.issue_type for issue in validation_issues]
 
     @pytest.mark.xfail  # TODO enable test when validation logic for quorum count is implemented
     @pytest.mark.parametrize('quorum_count', [1, 0, -1, 10, 'abc', sys.maxsize+1])
-    def is_request_body_valid__should_return_false_and_message_given_invalid_quorum_count(self, quorum_count):
+    def is_request_valid__should_return_false_and_message_given_invalid_quorum_count(self, quorum_count):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['quorum'] = quorum_count
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.INVALID_QUORUM_COUNT.key in [issue.issue_type for issue in validation_issues]
         invalid_quorum_count_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_QUORUM_COUNT.key)
         assert str(quorum_count) in invalid_quorum_count_issue.message
 
-    def is_request_body_valid__should_return_false_and_message_given_invalid_certificate_type_specified(self):
+    def is_request_valid__should_return_false_and_message_given_invalid_certificate_type_specified(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['caa-details']['certificate-type'] = 'invalid-certificate-type'
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.INVALID_CERTIFICATE_TYPE.key in [issue.issue_type for issue in validation_issues]
         invalid_certificate_type_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_CERTIFICATE_TYPE.key)
         assert 'invalid-certificate-type' in invalid_certificate_type_issue.message
 
-    def is_request_body_valid__should_return_false_and_message_given_missing_validation_method_for_dcv(self):
+    def is_request_valid__should_return_false_and_message_given_missing_validation_method_for_dcv(self):
         body = ValidRequestCreator.create_valid_dcv_check_request()
         del body['validation-method']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.DCV_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.MISSING_VALIDATION_METHOD.key in [issue.issue_type for issue in validation_issues]
 
-    def is_request_body_valid__should_return_false_and_message_given_invalid_validation_method_specified(self):
+    def is_request_valid__should_return_false_and_message_given_invalid_validation_method_specified(self):
         body = ValidRequestCreator.create_valid_dcv_check_request()
         # noinspection PyTypedDict
         body['validation-method'] = 'invalid-validation-method'
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.DCV_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.INVALID_VALIDATION_METHOD.key in [issue.issue_type for issue in validation_issues]
         invalid_validation_method_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_VALIDATION_METHOD.key)
         assert 'invalid-validation-method' in invalid_validation_method_issue.message
 
-    def is_request_body_valid__should_return_false_and_message_given_missing_validation_details_for_dcv(self):
+    def is_request_valid__should_return_false_and_message_given_missing_validation_details_for_dcv(self):
         body = ValidRequestCreator.create_valid_dcv_check_request()
         del body['validation-details']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.DCV_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.MISSING_VALIDATION_DETAILS.key in [issue.issue_type for issue in validation_issues]
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_GENERIC, DcvValidationMethod.HTTP_GENERIC,
                                                    DcvValidationMethod.TLS_USING_ALPN])
-    def is_request_body_valid__should_return_false_and_message_given_missing_expected_challenge_for_dcv(self, validation_method):
+    def is_request_valid__should_return_false_and_message_given_missing_expected_challenge_for_dcv(self, validation_method):
         body = ValidRequestCreator.create_valid_dcv_check_request(validation_method)
         del body['validation-details']['expected-challenge']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.DCV_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.MISSING_EXPECTED_CHALLENGE.key in [issue.issue_type for issue in validation_issues]
 
-    def is_request_body_valid__should_return_false_and_message_given_missing_prefix_for_dns_validation(self):
+    def is_request_valid__should_return_false_and_message_given_missing_prefix_for_dns_validation(self):
         body = ValidRequestCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
         del body['validation-details']['prefix']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.DCV_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.MISSING_PREFIX.key in [issue.issue_type for issue in validation_issues]
 
-    def is_request_body_valid__should_return_false_and_message_given_missing_record_type_for_dns_validation(self):
+    def is_request_valid__should_return_false_and_message_given_missing_record_type_for_dns_validation(self):
         body = ValidRequestCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
         del body['validation-details']['record-type']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.DCV_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.MISSING_RECORD_TYPE.key in [issue.issue_type for issue in validation_issues]
 
-    def is_request_body_valid__should_return_false_and_message_given_missing_path_for_http_validation(self):
+    def is_request_valid__should_return_false_and_message_given_missing_path_for_http_validation(self):
         body = ValidRequestCreator.create_valid_dcv_check_request(DcvValidationMethod.HTTP_GENERIC)
         del body['validation-details']['path']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.DCV_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert ValidationMessages.MISSING_PATH.key in [issue.issue_type for issue in validation_issues]
 
-    def is_request_body_valid__should_return_multiple_messages_given_multiple_validation_issues(self):
+    def is_request_valid__should_return_multiple_messages_given_multiple_validation_issues(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['api-version']
         del body['system-params']['identifier']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
-        assert is_body_valid is False
+        is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(RequestPath.CAA_CHECK, body, self.known_perspectives)
+        assert is_request_valid is False
         assert len(validation_issues) == 2
         assert ValidationMessages.MISSING_API_VERSION.key in [issue.issue_type for issue in validation_issues]
         assert ValidationMessages.MISSING_DOMAIN_OR_IP_TARGET.key in [issue.issue_type for issue in validation_issues]

--- a/tests/unit/test_mpic_request_validator.py
+++ b/tests/unit/test_mpic_request_validator.py
@@ -3,181 +3,189 @@ import sys
 import pytest
 
 from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvValidationMethod
-from aws_lambda_python.mpic_coordinator.domain.dns_record_type import DnsRecordType
 from aws_lambda_python.mpic_coordinator.messages.validation_messages import ValidationMessages
 from aws_lambda_python.mpic_coordinator.mpic_request_validator import MpicRequestValidator
+from valid_request_creator import ValidRequestCreator
 
 
 # noinspection PyMethodMayBeStatic
 class TestMpicRequestValidator:
-    def __create_valid_caa_check_request(self):
-        return {
-            'api-version': '1.0.0',
-            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
-            'caa-details': {'certificate-type': 'tls-server'}
-        }
+    @classmethod
+    def setup_class(cls):
+        cls.known_perspectives = ['p1', 'p2', 'p3', 'p4', 'p5', 'p6', 'p7', 'p8', 'p9', 'p10']
 
-    def __create_valid_dcv_check_request(self, validation_method=DcvValidationMethod.DNS_GENERIC):
-        validation_details = {}
-        match validation_method:
-            case DcvValidationMethod.DNS_GENERIC:
-                validation_details = {'prefix': 'test', 'record-type': DnsRecordType.A, 'expected-challenge': 'test'}
-            case DcvValidationMethod.HTTP_GENERIC:
-                validation_details = {'path': 'http://example.com', 'expected-challenge': 'test'}  # noqa (not https)
-            case DcvValidationMethod.TLS_USING_ALPN:
-                validation_details = {'expected-challenge': 'test'}
-        return {
-            'api-version': '1.0.0',
-            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
-            'validation-method': validation_method,
-            'validation-details': validation_details
-        }
-
-    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request(self):
-        body = self.__create_valid_caa_check_request()
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request_with_perspective_count(self):
+        body = ValidRequestCreator.create_valid_caa_check_request()
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is True
-        assert len(body_validation_issues) == 0
+        assert len(validation_issues) == 0
+
+    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request_with_perspective_list(self):
+        body = ValidRequestCreator.create_valid_caa_check_request()
+        body['system-params']['perspectives'] = '|'.join(self.known_perspectives[:6])
+        del body['system-params']['perspective-count']
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        assert is_body_valid is True
+        assert len(validation_issues) == 0
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_GENERIC, DcvValidationMethod.HTTP_GENERIC,
                                                    DcvValidationMethod.TLS_USING_ALPN])
     def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_dcv_check_request(self, validation_method):
-        body = self.__create_valid_dcv_check_request(validation_method)
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
+        body = ValidRequestCreator.create_valid_dcv_check_request(validation_method)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
         assert is_body_valid is True
-        assert len(body_validation_issues) == 0
+        assert len(validation_issues) == 0
 
     def is_request_body_valid__should_return_false_and_message_given_missing_api_version(self):
-        body = self.__create_valid_caa_check_request()
+        body = ValidRequestCreator.create_valid_caa_check_request()
         del body['api-version']  # remove api-version field
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
-        assert ValidationMessages.MISSING_API_VERSION.key in [issue.issue_type for issue in body_validation_issues]
+        assert ValidationMessages.MISSING_API_VERSION.key in [issue.issue_type for issue in validation_issues]
 
     @pytest.mark.parametrize('api_version', ['0.0.1', '5.0.0', '1;0;0', '1.', '100', 'bad-api-version'])  # ~=1.0.0 is valid
     def is_request_body_valid__should_return_false_and_message_given_invalid_api_version(self, api_version):
-        body = self.__create_valid_caa_check_request()
+        body = ValidRequestCreator.create_valid_caa_check_request()
         body['api-version'] = api_version
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
-        assert ValidationMessages.INVALID_API_VERSION.key in [issue.issue_type for issue in body_validation_issues]
-        # get the message for the first issue with the key 'invalid-api-version'
-        invalid_api_version_issue = next(issue for issue in body_validation_issues if issue.issue_type == ValidationMessages.INVALID_API_VERSION.key)
+        assert ValidationMessages.INVALID_API_VERSION.key in [issue.issue_type for issue in validation_issues]
+        invalid_api_version_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_API_VERSION.key)
         assert api_version in invalid_api_version_issue.message
 
     @pytest.mark.parametrize('request_path', ['/invalid-path'])  # do any other path types need testing?
     def is_request_body_valid__should_return_false_and_message_given_unsupported_request_path(self, request_path):
-        body = self.__create_valid_caa_check_request()
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid(request_path, body)
+        body = ValidRequestCreator.create_valid_caa_check_request()
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(request_path, body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'unsupported-request-path' in body_validation_issues
+        assert ValidationMessages.UNSUPPORTED_REQUEST_PATH.key in [issue.issue_type for issue in validation_issues]
+        unsupported_request_path_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.UNSUPPORTED_REQUEST_PATH.key)
+        assert request_path in unsupported_request_path_issue.message
 
     def is_request_body_valid__should_return_false_and_message_given_missing_system_params(self):
-        body = self.__create_valid_caa_check_request()
+        body = ValidRequestCreator.create_valid_caa_check_request()
         del body['system-params']  # remove system-params field
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'missing-system-params' in body_validation_issues
+        assert ValidationMessages.MISSING_SYSTEM_PARAMS.key in [issue.issue_type for issue in validation_issues]
 
     # TODO rename when you rename identifier field in the spec (recommend "domain_or_ip_target" for highest clarity)
     def is_request_body_valid__should_return_false_and_message_given_missing_identifier(self):
-        body = self.__create_valid_caa_check_request()
+        body = ValidRequestCreator.create_valid_caa_check_request()
         del body['system-params']['identifier']  # remove identifier field
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'missing-domain-or-ip-target' in body_validation_issues
+        assert ValidationMessages.MISSING_DOMAIN_OR_IP_TARGET.key in [issue.issue_type for issue in validation_issues]
 
     def is_request_body_valid__should_return_false_and_message_given_both_perspective_and_perspective_count_present(self):
-        body = self.__create_valid_caa_check_request()
-        body['system-params']['perspectives'] = ['perspective1', 'perspective2']
+        body = ValidRequestCreator.create_valid_caa_check_request()
+        body['system-params']['perspectives'] = '|'.join(self.known_perspectives[:6])
         body['system-params']['perspective-count'] = 2
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'contains-both-perspectives-and-perspective-count' in body_validation_issues
+        assert ValidationMessages.PERSPECTIVES_WITH_PERSPECTIVE_COUNT.key in [issue.issue_type for issue in validation_issues]
 
-    @pytest.mark.xfail  # TODO enable test when validation logic for perspective count is implemented
     @pytest.mark.parametrize('perspective_count', [1, 0, -1, 'abc', sys.maxsize+1])
     def is_request_body_valid__should_return_false_and_message_given_invalid_perspective_count(self, perspective_count):
-        body = self.__create_valid_caa_check_request()
+        body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['perspective-count'] = perspective_count
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'invalid-perspective-count' in body_validation_issues
+        assert ValidationMessages.INVALID_PERSPECTIVE_COUNT.key in [issue.issue_type for issue in validation_issues]
+        invalid_perspective_count_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_PERSPECTIVE_COUNT.key)
+        assert str(perspective_count) in invalid_perspective_count_issue.message
+
+    def is_request_body_valid__should_return_false_and_message_given_invalid_perspective_list(self):
+        body = ValidRequestCreator.create_valid_caa_check_request()
+        del body['system-params']['perspective-count']
+        body['system-params']['perspectives'] = 'bad_p1|bad_p2|bad_p3|bad_p4|bad_p5|bad_p6'
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        assert is_body_valid is False
+        assert ValidationMessages.INVALID_PERSPECTIVE_LIST.key in [issue.issue_type for issue in validation_issues]
 
     @pytest.mark.xfail  # TODO enable test when validation logic for quorum count is implemented
     @pytest.mark.parametrize('quorum_count', [1, 0, -1, 10, 'abc', sys.maxsize+1])
     def is_request_body_valid__should_return_false_and_message_given_invalid_quorum_count(self, quorum_count):
-        body = self.__create_valid_caa_check_request()
+        body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['quorum'] = quorum_count
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'invalid-quorum-count' in body_validation_issues
-
-    def is_request_body_valid__should_return_false_and_message_given_missing_certificate_type_for_caa_check(self):
-        body = self.__create_valid_caa_check_request()
-        del body['caa-details']['certificate-type']
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
-        assert is_body_valid is False
-        assert 'missing-certificate-type-in-caa-details' in body_validation_issues
+        assert ValidationMessages.INVALID_QUORUM_COUNT.key in [issue.issue_type for issue in validation_issues]
+        invalid_quorum_count_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_QUORUM_COUNT.key)
+        assert str(quorum_count) in invalid_quorum_count_issue.message
 
     def is_request_body_valid__should_return_false_and_message_given_invalid_certificate_type_specified(self):
-        body = self.__create_valid_caa_check_request()
+        body = ValidRequestCreator.create_valid_caa_check_request()
         body['caa-details']['certificate-type'] = 'invalid-certificate-type'
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'invalid-certificate-type-in-caa-details' in body_validation_issues
+        assert ValidationMessages.INVALID_CERTIFICATE_TYPE.key in [issue.issue_type for issue in validation_issues]
+        invalid_certificate_type_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_CERTIFICATE_TYPE.key)
+        assert 'invalid-certificate-type' in invalid_certificate_type_issue.message
 
     def is_request_body_valid__should_return_false_and_message_given_missing_validation_method_for_dcv(self):
-        body = self.__create_valid_dcv_check_request()
+        body = ValidRequestCreator.create_valid_dcv_check_request()
         del body['validation-method']
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'missing-validation-method' in body_validation_issues
+        assert ValidationMessages.MISSING_VALIDATION_METHOD.key in [issue.issue_type for issue in validation_issues]
 
     def is_request_body_valid__should_return_false_and_message_given_invalid_validation_method_specified(self):
-        body = self.__create_valid_dcv_check_request()
+        body = ValidRequestCreator.create_valid_dcv_check_request()
         # noinspection PyTypedDict
         body['validation-method'] = 'invalid-validation-method'
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'invalid-validation-method' in body_validation_issues
+        assert ValidationMessages.INVALID_VALIDATION_METHOD.key in [issue.issue_type for issue in validation_issues]
+        invalid_validation_method_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_VALIDATION_METHOD.key)
+        assert 'invalid-validation-method' in invalid_validation_method_issue.message
 
     def is_request_body_valid__should_return_false_and_message_given_missing_validation_details_for_dcv(self):
-        body = self.__create_valid_dcv_check_request()
+        body = ValidRequestCreator.create_valid_dcv_check_request()
         del body['validation-details']
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'missing-validation-details' in body_validation_issues
+        assert ValidationMessages.MISSING_VALIDATION_DETAILS.key in [issue.issue_type for issue in validation_issues]
 
     @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_GENERIC, DcvValidationMethod.HTTP_GENERIC,
                                                    DcvValidationMethod.TLS_USING_ALPN])
     def is_request_body_valid__should_return_false_and_message_given_missing_expected_challenge_for_dcv(self, validation_method):
-        body = self.__create_valid_dcv_check_request(validation_method)
+        body = ValidRequestCreator.create_valid_dcv_check_request(validation_method)
         del body['validation-details']['expected-challenge']
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'missing-expected-challenge-in-validation-details' in body_validation_issues
+        assert ValidationMessages.MISSING_EXPECTED_CHALLENGE.key in [issue.issue_type for issue in validation_issues]
 
     def is_request_body_valid__should_return_false_and_message_given_missing_prefix_for_dns_validation(self):
-        body = self.__create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
+        body = ValidRequestCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
         del body['validation-details']['prefix']
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'missing-prefix-in-validation-details' in body_validation_issues
+        assert ValidationMessages.MISSING_PREFIX.key in [issue.issue_type for issue in validation_issues]
 
     def is_request_body_valid__should_return_false_and_message_given_missing_record_type_for_dns_validation(self):
-        body = self.__create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
+        body = ValidRequestCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
         del body['validation-details']['record-type']
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'missing-record-type-in-validation-details' in body_validation_issues
+        assert ValidationMessages.MISSING_RECORD_TYPE.key in [issue.issue_type for issue in validation_issues]
 
     def is_request_body_valid__should_return_false_and_message_given_missing_path_for_http_validation(self):
-        body = self.__create_valid_dcv_check_request(DcvValidationMethod.HTTP_GENERIC)
+        body = ValidRequestCreator.create_valid_dcv_check_request(DcvValidationMethod.HTTP_GENERIC)
         del body['validation-details']['path']
-        is_body_valid, body_validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
         assert is_body_valid is False
-        assert 'missing-path-in-validation-details' in body_validation_issues
+        assert ValidationMessages.MISSING_PATH.key in [issue.issue_type for issue in validation_issues]
+
+    def is_request_body_valid__should_return_multiple_messages_given_multiple_validation_issues(self):
+        body = ValidRequestCreator.create_valid_caa_check_request()
+        del body['api-version']
+        del body['system-params']['identifier']
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        assert is_body_valid is False
+        assert len(validation_issues) == 2
+        assert ValidationMessages.MISSING_API_VERSION.key in [issue.issue_type for issue in validation_issues]
+        assert ValidationMessages.MISSING_DOMAIN_OR_IP_TARGET.key in [issue.issue_type for issue in validation_issues]
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_mpic_request_validator.py
+++ b/tests/unit/test_mpic_request_validator.py
@@ -3,6 +3,7 @@ import sys
 import pytest
 
 from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvValidationMethod
+from aws_lambda_python.mpic_coordinator.domain.request_paths import RequestPaths
 from aws_lambda_python.mpic_coordinator.messages.validation_messages import ValidationMessages
 from aws_lambda_python.mpic_coordinator.mpic_request_validator import MpicRequestValidator
 from valid_request_creator import ValidRequestCreator
@@ -16,7 +17,7 @@ class TestMpicRequestValidator:
 
     def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_caa_check_request_with_perspective_count(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is True
         assert len(validation_issues) == 0
 
@@ -24,7 +25,7 @@ class TestMpicRequestValidator:
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['perspectives'] = self.known_perspectives[:6]
         del body['system-params']['perspective-count']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is True
         assert len(validation_issues) == 0
 
@@ -32,14 +33,20 @@ class TestMpicRequestValidator:
                                                    DcvValidationMethod.TLS_USING_ALPN])
     def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_dcv_check_request(self, validation_method):
         body = ValidRequestCreator.create_valid_dcv_check_request(validation_method)
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
+        assert is_body_valid is True
+        assert len(validation_issues) == 0
+
+    def is_request_body_valid__should_return_true_and_empty_message_list_given_valid_dcv_with_caa_check_request(self):
+        body = ValidRequestCreator.create_valid_dcv_with_caa_check_request()
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_WITH_CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is True
         assert len(validation_issues) == 0
 
     def is_request_body_valid__should_return_false_and_message_given_missing_api_version(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['api-version']  # remove api-version field
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.MISSING_API_VERSION.key in [issue.issue_type for issue in validation_issues]
 
@@ -47,7 +54,7 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_invalid_api_version(self, api_version):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['api-version'] = api_version
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.INVALID_API_VERSION.key in [issue.issue_type for issue in validation_issues]
         invalid_api_version_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_API_VERSION.key)
@@ -65,7 +72,7 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_missing_system_params(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['system-params']  # remove system-params field
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.MISSING_SYSTEM_PARAMS.key in [issue.issue_type for issue in validation_issues]
 
@@ -73,7 +80,7 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_missing_identifier(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['system-params']['identifier']  # remove identifier field
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.MISSING_DOMAIN_OR_IP_TARGET.key in [issue.issue_type for issue in validation_issues]
 
@@ -81,7 +88,7 @@ class TestMpicRequestValidator:
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['perspectives'] = self.known_perspectives[:6]
         body['system-params']['perspective-count'] = 2
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.PERSPECTIVES_WITH_PERSPECTIVE_COUNT.key in [issue.issue_type for issue in validation_issues]
 
@@ -89,7 +96,7 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_invalid_perspective_count(self, perspective_count):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['perspective-count'] = perspective_count
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.INVALID_PERSPECTIVE_COUNT.key in [issue.issue_type for issue in validation_issues]
         invalid_perspective_count_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_PERSPECTIVE_COUNT.key)
@@ -99,7 +106,7 @@ class TestMpicRequestValidator:
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['system-params']['perspective-count']
         body['system-params']['perspectives'] = ['bad_p1', 'bad_p2', 'bad_p3', 'bad_p4', 'bad_p5', 'bad_p6']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.INVALID_PERSPECTIVE_LIST.key in [issue.issue_type for issue in validation_issues]
 
@@ -108,7 +115,7 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_invalid_quorum_count(self, quorum_count):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['system-params']['quorum'] = quorum_count
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.INVALID_QUORUM_COUNT.key in [issue.issue_type for issue in validation_issues]
         invalid_quorum_count_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_QUORUM_COUNT.key)
@@ -117,7 +124,7 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_invalid_certificate_type_specified(self):
         body = ValidRequestCreator.create_valid_caa_check_request()
         body['caa-details']['certificate-type'] = 'invalid-certificate-type'
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.INVALID_CERTIFICATE_TYPE.key in [issue.issue_type for issue in validation_issues]
         invalid_certificate_type_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_CERTIFICATE_TYPE.key)
@@ -126,7 +133,7 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_missing_validation_method_for_dcv(self):
         body = ValidRequestCreator.create_valid_dcv_check_request()
         del body['validation-method']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.MISSING_VALIDATION_METHOD.key in [issue.issue_type for issue in validation_issues]
 
@@ -134,7 +141,7 @@ class TestMpicRequestValidator:
         body = ValidRequestCreator.create_valid_dcv_check_request()
         # noinspection PyTypedDict
         body['validation-method'] = 'invalid-validation-method'
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.INVALID_VALIDATION_METHOD.key in [issue.issue_type for issue in validation_issues]
         invalid_validation_method_issue = next(issue for issue in validation_issues if issue.issue_type == ValidationMessages.INVALID_VALIDATION_METHOD.key)
@@ -143,7 +150,7 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_missing_validation_details_for_dcv(self):
         body = ValidRequestCreator.create_valid_dcv_check_request()
         del body['validation-details']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.MISSING_VALIDATION_DETAILS.key in [issue.issue_type for issue in validation_issues]
 
@@ -152,28 +159,28 @@ class TestMpicRequestValidator:
     def is_request_body_valid__should_return_false_and_message_given_missing_expected_challenge_for_dcv(self, validation_method):
         body = ValidRequestCreator.create_valid_dcv_check_request(validation_method)
         del body['validation-details']['expected-challenge']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.MISSING_EXPECTED_CHALLENGE.key in [issue.issue_type for issue in validation_issues]
 
     def is_request_body_valid__should_return_false_and_message_given_missing_prefix_for_dns_validation(self):
         body = ValidRequestCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
         del body['validation-details']['prefix']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.MISSING_PREFIX.key in [issue.issue_type for issue in validation_issues]
 
     def is_request_body_valid__should_return_false_and_message_given_missing_record_type_for_dns_validation(self):
         body = ValidRequestCreator.create_valid_dcv_check_request(DcvValidationMethod.DNS_GENERIC)
         del body['validation-details']['record-type']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.MISSING_RECORD_TYPE.key in [issue.issue_type for issue in validation_issues]
 
     def is_request_body_valid__should_return_false_and_message_given_missing_path_for_http_validation(self):
         body = ValidRequestCreator.create_valid_dcv_check_request(DcvValidationMethod.HTTP_GENERIC)
         del body['validation-details']['path']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/validation', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.DCV_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert ValidationMessages.MISSING_PATH.key in [issue.issue_type for issue in validation_issues]
 
@@ -181,7 +188,7 @@ class TestMpicRequestValidator:
         body = ValidRequestCreator.create_valid_caa_check_request()
         del body['api-version']
         del body['system-params']['identifier']
-        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid('/caa-check', body, self.known_perspectives)
+        is_body_valid, validation_issues = MpicRequestValidator.is_request_body_valid(RequestPaths.CAA_CHECK, body, self.known_perspectives)
         assert is_body_valid is False
         assert len(validation_issues) == 2
         assert ValidationMessages.MISSING_API_VERSION.key in [issue.issue_type for issue in validation_issues]

--- a/tests/unit/valid_request_creator.py
+++ b/tests/unit/valid_request_creator.py
@@ -7,7 +7,7 @@ class ValidRequestCreator:
     def create_valid_caa_check_request():
         return {
             'api-version': '1.0.0',
-            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
+            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum-count': 4},
             'caa-details': {'certificate-type': 'tls-server'}
         }
 
@@ -15,7 +15,7 @@ class ValidRequestCreator:
     def create_valid_dcv_check_request(validation_method=DcvValidationMethod.DNS_GENERIC):
         return {
             'api-version': '1.0.0',
-            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
+            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum-count': 4},
             'validation-method': validation_method,
             'validation-details': ValidRequestCreator.create_validation_details(validation_method)
         }
@@ -24,7 +24,7 @@ class ValidRequestCreator:
     def create_valid_dcv_with_caa_check_request(validation_method=DcvValidationMethod.DNS_GENERIC):
         return {
             'api-version': '1.0.0',
-            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
+            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum-count': 4},
             'caa-details': {'certificate-type': 'tls-server'},
             'validation-method': validation_method,
             'validation-details': ValidRequestCreator.create_validation_details(validation_method)

--- a/tests/unit/valid_request_creator.py
+++ b/tests/unit/valid_request_creator.py
@@ -1,0 +1,29 @@
+from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvValidationMethod
+from aws_lambda_python.mpic_coordinator.domain.dns_record_type import DnsRecordType
+
+
+class ValidRequestCreator:
+    @staticmethod
+    def create_valid_caa_check_request():
+        return {
+            'api-version': '1.0.0',
+            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
+            'caa-details': {'certificate-type': 'tls-server'}
+        }
+
+    @staticmethod
+    def create_valid_dcv_check_request(validation_method=DcvValidationMethod.DNS_GENERIC):
+        validation_details = {}
+        match validation_method:
+            case DcvValidationMethod.DNS_GENERIC:
+                validation_details = {'prefix': 'test', 'record-type': DnsRecordType.A, 'expected-challenge': 'test'}
+            case DcvValidationMethod.HTTP_GENERIC:
+                validation_details = {'path': 'http://example.com', 'expected-challenge': 'test'}  # noqa (not https)
+            case DcvValidationMethod.TLS_USING_ALPN:
+                validation_details = {'expected-challenge': 'test'}
+        return {
+            'api-version': '1.0.0',
+            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
+            'validation-method': validation_method,
+            'validation-details': validation_details
+        }

--- a/tests/unit/valid_request_creator.py
+++ b/tests/unit/valid_request_creator.py
@@ -37,7 +37,7 @@ class ValidRequestCreator:
             case DcvValidationMethod.DNS_GENERIC:
                 validation_details = {'prefix': 'test', 'record-type': DnsRecordType.A, 'expected-challenge': 'test'}
             case DcvValidationMethod.HTTP_GENERIC:
-                validation_details = {'path': 'http://example.com', 'expected-challenge': 'test'}
+                validation_details = {'path': 'http://example.com', 'expected-challenge': 'test'}  # noqa E501 (http)
             case DcvValidationMethod.TLS_USING_ALPN:
                 validation_details = {'expected-challenge': 'test'}
         return validation_details

--- a/tests/unit/valid_request_creator.py
+++ b/tests/unit/valid_request_creator.py
@@ -1,3 +1,4 @@
+from aws_lambda_python.mpic_coordinator.config.service_config import API_VERSION
 from aws_lambda_python.mpic_coordinator.domain.dcv_validation_method import DcvValidationMethod
 from aws_lambda_python.mpic_coordinator.domain.dns_record_type import DnsRecordType
 
@@ -6,7 +7,7 @@ class ValidRequestCreator:
     @staticmethod
     def create_valid_caa_check_request():
         return {
-            'api-version': '1.0.0',
+            'api-version': API_VERSION,
             'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum-count': 4},
             'caa-details': {'certificate-type': 'tls-server'}
         }
@@ -14,7 +15,7 @@ class ValidRequestCreator:
     @staticmethod
     def create_valid_dcv_check_request(validation_method=DcvValidationMethod.DNS_GENERIC):
         return {
-            'api-version': '1.0.0',
+            'api-version': API_VERSION,
             'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum-count': 4},
             'validation-method': validation_method,
             'validation-details': ValidRequestCreator.create_validation_details(validation_method)
@@ -23,7 +24,7 @@ class ValidRequestCreator:
     @staticmethod
     def create_valid_dcv_with_caa_check_request(validation_method=DcvValidationMethod.DNS_GENERIC):
         return {
-            'api-version': '1.0.0',
+            'api-version': API_VERSION,
             'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum-count': 4},
             'caa-details': {'certificate-type': 'tls-server'},
             'validation-method': validation_method,

--- a/tests/unit/valid_request_creator.py
+++ b/tests/unit/valid_request_creator.py
@@ -13,17 +13,31 @@ class ValidRequestCreator:
 
     @staticmethod
     def create_valid_dcv_check_request(validation_method=DcvValidationMethod.DNS_GENERIC):
+        return {
+            'api-version': '1.0.0',
+            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
+            'validation-method': validation_method,
+            'validation-details': ValidRequestCreator.create_validation_details(validation_method)
+        }
+
+    @staticmethod
+    def create_valid_dcv_with_caa_check_request(validation_method=DcvValidationMethod.DNS_GENERIC):
+        return {
+            'api-version': '1.0.0',
+            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
+            'caa-details': {'certificate-type': 'tls-server'},
+            'validation-method': validation_method,
+            'validation-details': ValidRequestCreator.create_validation_details(validation_method)
+        }
+
+    @classmethod
+    def create_validation_details(cls, validation_method):
         validation_details = {}
         match validation_method:
             case DcvValidationMethod.DNS_GENERIC:
                 validation_details = {'prefix': 'test', 'record-type': DnsRecordType.A, 'expected-challenge': 'test'}
             case DcvValidationMethod.HTTP_GENERIC:
-                validation_details = {'path': 'http://example.com', 'expected-challenge': 'test'}  # noqa (not https)
+                validation_details = {'path': 'http://example.com', 'expected-challenge': 'test'}
             case DcvValidationMethod.TLS_USING_ALPN:
                 validation_details = {'expected-challenge': 'test'}
-        return {
-            'api-version': '1.0.0',
-            'system-params': {'identifier': 'test', 'perspective-count': 6, 'quorum': 4},
-            'validation-method': validation_method,
-            'validation-details': validation_details
-        }
+        return validation_details


### PR DESCRIPTION
Added a class to validate the incoming request (with tests). Following the current API spec for validation.
Refactored MpicCoordinator further, extracting some logic into separate methods. Added a few tests around them.
Reworked building of async lambda (perspective) function calls to use a class instead of just a tuple.
Using more Enums and constants to avoid some of the "magic strings" in the codebase.
Extracted building of the HTTP response into a separate class (with tests).
Added a unit test and an e2e test to ensure integration of the request validator with MpicCoordinator.
Fixed some broken stuff! The previous logic may have invalidated dcv-with-caa checks; tests now exist to prevent that regression. 
**Caution**: we will need to rename some fields in the API and flesh out the specified response object following this merge. And take another pass through it to make sure everything that's require is enforced and everything optional is treated as such.