### PR TITLE
Addressing DcvValidationDetails deserialization

### DIFF
--- a/src/aws_lambda_python/common_domain/check_parameters.py
+++ b/src/aws_lambda_python/common_domain/check_parameters.py
@@ -1,8 +1,7 @@
 from abc import ABC
 from typing import Literal, Union
 
-from pydantic import BaseModel, Field
-from typing_extensions import Annotated
+from pydantic import BaseModel
 
 from aws_lambda_python.common_domain.enum.certificate_type import CertificateType
 from aws_lambda_python.common_domain.enum.dcv_validation_method import DcvValidationMethod
@@ -39,7 +38,3 @@ class DcvDnsGenericValidationDetails(DcvValidationDetails):
 
 class DcvCheckParameters(BaseModel):
     validation_details: Union[DcvHttpGenericValidationDetails, DcvDnsGenericValidationDetails]
-
-
-# CheckParameters =
-# AnnotatedCheckResponse = Annotated[CheckParameters, Field(discriminator='validation_method')]

--- a/src/aws_lambda_python/common_domain/check_parameters.py
+++ b/src/aws_lambda_python/common_domain/check_parameters.py
@@ -1,4 +1,8 @@
-from pydantic import BaseModel
+from abc import ABC
+from typing import Literal, Union
+
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated
 
 from aws_lambda_python.common_domain.enum.certificate_type import CertificateType
 from aws_lambda_python.common_domain.enum.dcv_validation_method import DcvValidationMethod
@@ -10,10 +14,8 @@ class CaaCheckParameters(BaseModel):
     caa_domains: list[str] | None = None
 
 
-class DcvValidationDetails(BaseModel):
-    dns_name_prefix: str | None = None
-    dns_record_type: DnsRecordType | None = None
-    http_token_path: str | None = None
+class DcvValidationDetails(BaseModel, ABC):
+    validation_method: DcvValidationMethod
     challenge_value: str
     # DNS records have 5 fields: name, ttl, class, type, rdata (which can be multipart itself)
     # A or AAAA: name=domain_name type=A <rdata:address> (ip address)
@@ -21,6 +23,23 @@ class DcvValidationDetails(BaseModel):
     # TXT: name=domain_name type=TXT <rdata:text> (freeform text)
 
 
+class DcvHttpGenericValidationDetails(DcvValidationDetails):
+    validation_method: Literal[DcvValidationMethod.HTTP_GENERIC] = DcvValidationMethod.HTTP_GENERIC
+    http_token_path: str
+
+
+class DcvDnsGenericValidationDetails(DcvValidationDetails):
+    validation_method: Literal[DcvValidationMethod.DNS_GENERIC] = DcvValidationMethod.DNS_GENERIC
+    dns_name_prefix: str
+    dns_record_type: DnsRecordType
+
+
+# TODO DcvAcmeValidationDetails
+
+
 class DcvCheckParameters(BaseModel):
-    validation_method: DcvValidationMethod
-    validation_details: DcvValidationDetails
+    validation_details: Union[DcvHttpGenericValidationDetails, DcvDnsGenericValidationDetails]
+
+
+# CheckParameters =
+# AnnotatedCheckResponse = Annotated[CheckParameters, Field(discriminator='validation_method')]

--- a/src/aws_lambda_python/common_domain/enum/dcv_validation_method.py
+++ b/src/aws_lambda_python/common_domain/enum/dcv_validation_method.py
@@ -4,4 +4,4 @@ from enum import StrEnum
 class DcvValidationMethod(StrEnum):
     HTTP_GENERIC = 'http-generic'  # TODO rename to something better
     DNS_GENERIC = 'dns-generic'  # TODO rename to something better
-    TLS_USING_ALPN = 'tls-using-alpn'  # TODO remove unless it's supported (is it supported?)
+    # ACME = 'acme'  # TODO implement ACME validation... and later TLS_USING_ALPN

--- a/src/aws_lambda_python/mpic_coordinator/domain/mpic_request.py
+++ b/src/aws_lambda_python/mpic_coordinator/domain/mpic_request.py
@@ -32,15 +32,6 @@ class MpicDcvRequest(BaseMpicRequest):
     check_type: Literal[CheckType.DCV] = CheckType.DCV
     dcv_check_parameters: DcvCheckParameters
 
-    @model_validator(mode='after')
-    def check_required_fields_per_validation_method(self) -> 'MpicDcvRequest':
-        if self.dcv_check_parameters.validation_method == DcvValidationMethod.HTTP_GENERIC:
-            assert self.dcv_check_parameters.validation_details.http_token_path, f"http_token_path is required for {DcvValidationMethod.HTTP_GENERIC} validation"
-        elif self.dcv_check_parameters.validation_method == DcvValidationMethod.DNS_GENERIC:
-            assert self.dcv_check_parameters.validation_details.dns_record_type, f"dns_record_type is required for {DcvValidationMethod.DNS_GENERIC} validation"
-            assert self.dcv_check_parameters.validation_details.dns_name_prefix, f"dns_name_prefix is required for {DcvValidationMethod.DNS_GENERIC} validation"
-        return self
-
 
 class MpicDcvWithCaaRequest(MpicDcvRequest):  # inherits from MpicDcvRequest rather than BaseMpicRequest
     check_type: Literal[CheckType.DCV_WITH_CAA] = CheckType.DCV_WITH_CAA

--- a/src/aws_lambda_python/mpic_dcv_checker/mpic_dcv_checker.py
+++ b/src/aws_lambda_python/mpic_dcv_checker/mpic_dcv_checker.py
@@ -20,7 +20,7 @@ class MpicDcvChecker:
     def check_dcv(self, event):
         dcv_request = DcvCheckRequest.model_validate(event)
 
-        match dcv_request.dcv_check_parameters.validation_method:
+        match dcv_request.dcv_check_parameters.validation_details.validation_method:
             case DcvValidationMethod.HTTP_GENERIC:
                 return self.perform_http_validation(dcv_request)
             case DcvValidationMethod.DNS_GENERIC:

--- a/tests/integration/test_deployed_mpic_api.py
+++ b/tests/integration/test_deployed_mpic_api.py
@@ -3,11 +3,10 @@ import sys
 import pytest
 from pydantic import TypeAdapter
 
-from aws_lambda_python.common_domain.check_parameters import CaaCheckParameters
-from aws_lambda_python.common_domain.check_parameters import DcvCheckParameters, DcvValidationDetails
+from aws_lambda_python.common_domain.check_parameters import CaaCheckParameters, DcvHttpGenericValidationDetails
+from aws_lambda_python.common_domain.check_parameters import DcvCheckParameters
 from aws_lambda_python.common_domain.enum.certificate_type import CertificateType
 from aws_lambda_python.common_domain.enum.check_type import CheckType
-from aws_lambda_python.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from aws_lambda_python.mpic_coordinator.domain.mpic_request import MpicCaaRequest
 from aws_lambda_python.mpic_coordinator.domain.mpic_request import MpicDcvRequest
 from aws_lambda_python.mpic_coordinator.domain.mpic_orchestration_parameters import MpicRequestOrchestrationParameters
@@ -146,9 +145,8 @@ class TestDeployedMpicApi:
             domain_or_ip_target='example.com',
             orchestration_parameters=MpicRequestOrchestrationParameters(perspective_count=3, quorum_count=2),
             dcv_check_parameters=DcvCheckParameters(
-                validation_method=DcvValidationMethod.HTTP_GENERIC,
-                validation_details=DcvValidationDetails(dns_name_prefix=None, dns_record_type=None, http_token_path='/',
-                                                        challenge_value='test')
+                validation_details=DcvHttpGenericValidationDetails(http_token_path='/',
+                                                                   challenge_value='test')
             )
         )
 
@@ -163,9 +161,8 @@ class TestDeployedMpicApi:
         request = MpicDcvRequest(
             domain_or_ip_target='ifconfig.me',
             dcv_check_parameters=DcvCheckParameters(
-                validation_method=DcvValidationMethod.HTTP_GENERIC,
-                validation_details=DcvValidationDetails(http_token_path='/',
-                                                        challenge_value='test')
+                validation_details=DcvHttpGenericValidationDetails(http_token_path='/',
+                                                                   challenge_value='test')
             )
         )
 

--- a/tests/unit/test_mpic_coordinator.py
+++ b/tests/unit/test_mpic_coordinator.py
@@ -136,7 +136,7 @@ class TestMpicCoordinator:
         call_list = mpic_coordinator.collect_async_calls_to_issue(request, perspectives_to_use)
         assert len(call_list) == 6
         assert set(map(lambda call_result: call_result.check_type, call_list)) == {CheckType.DCV}  # ensure each call is of type 'dcv'
-        assert all(call.check_request.dcv_check_parameters.validation_method == DcvValidationMethod.DNS_GENERIC for call in call_list)
+        assert all(call.check_request.dcv_check_parameters.validation_details.validation_method == DcvValidationMethod.DNS_GENERIC for call in call_list)
         assert all(call.check_request.dcv_check_parameters.validation_details.dns_name_prefix == 'test' for call in call_list)
 
     def collect_async_calls_to_issue__should_have_caa_and_dcv_calls_given_dcv_with_caa_check_type(self, set_env_variables):

--- a/tests/unit/test_mpic_dcv_checker.py
+++ b/tests/unit/test_mpic_dcv_checker.py
@@ -2,7 +2,8 @@ import json
 
 import dns
 import pytest
-from aws_lambda_python.common_domain.check_parameters import DcvCheckParameters, DcvValidationDetails
+from aws_lambda_python.common_domain.check_parameters import DcvCheckParameters, \
+    DcvHttpGenericValidationDetails, DcvDnsGenericValidationDetails
 from aws_lambda_python.common_domain.check_request import DcvCheckRequest
 from aws_lambda_python.common_domain.check_response import DcvCheckResponse, DcvCheckResponseDetails
 from aws_lambda_python.common_domain.enum.dcv_validation_method import DcvValidationMethod
@@ -31,8 +32,7 @@ class TestMpicDcvChecker:
     def create_http_check_request():
         return DcvCheckRequest(domain_or_ip_target='example.com',
                                dcv_check_parameters=DcvCheckParameters(
-                                   validation_method=DcvValidationMethod.HTTP_GENERIC,
-                                   validation_details=DcvValidationDetails(
+                                   validation_details=DcvHttpGenericValidationDetails(
                                        http_token_path='/.well-known/pki_validation/token111_ca1.txt',
                                        challenge_value='challenge_111')
                                ))
@@ -41,8 +41,7 @@ class TestMpicDcvChecker:
     def create_dns_check_request(record_type=DnsRecordType.TXT):
         return DcvCheckRequest(domain_or_ip_target='example.com',
                                dcv_check_parameters=DcvCheckParameters(
-                                   validation_method=DcvValidationMethod.DNS_GENERIC,
-                                   validation_details=DcvValidationDetails(
+                                   validation_details=DcvDnsGenericValidationDetails(
                                        dns_name_prefix='_dnsauth',
                                        dns_record_type=record_type,
                                        challenge_value=f"{record_type}_challenge_111.ca1.com.")

--- a/tests/unit/test_mpic_dcv_request.py
+++ b/tests/unit/test_mpic_dcv_request.py
@@ -37,16 +37,16 @@ class TestMpicDcvRequest:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'dcv_check_parameters' in str(validation_error.value)
 
-    def model_validate_json__should_throw_validation_error_given_missing_validation_method(self):
+    def model_validate_json__should_throw_validation_error_given_missing_validation_method_in_validation_details(self):
         request = ValidRequestCreator.create_valid_dcv_mpic_request()
-        request.dcv_check_parameters.validation_method = None
+        request.dcv_check_parameters.validation_details.validation_method = None
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump()))
         assert 'validation_method' in str(validation_error.value)
 
-    def model_validate_json__should_throw_validation_error_given_invalid_validation_method(self):
+    def model_validate_json__should_throw_validation_error_given_invalid_validation_method_in_validation_details(self):
         request = ValidRequestCreator.create_valid_dcv_mpic_request()
-        request.dcv_check_parameters.validation_method = 'invalid'
+        request.dcv_check_parameters.validation_details.validation_method = 'invalid'
         with pytest.raises(pydantic.ValidationError) as validation_error:
             MpicDcvRequest.model_validate_json(json.dumps(request.model_dump(warnings=False)))
         assert 'validation_method' in str(validation_error.value)

--- a/tests/unit/test_mpic_request_validator.py
+++ b/tests/unit/test_mpic_request_validator.py
@@ -43,8 +43,7 @@ class TestMpicRequestValidator:
         assert is_request_valid is False
         assert MpicRequestValidationMessages.PERSPECTIVES_NOT_IN_DIAGNOSTIC_MODE.key in [issue.issue_type for issue in validation_issues]
 
-    @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_GENERIC, DcvValidationMethod.HTTP_GENERIC,
-                                                   DcvValidationMethod.TLS_USING_ALPN])
+    @pytest.mark.parametrize('validation_method', [DcvValidationMethod.DNS_GENERIC, DcvValidationMethod.HTTP_GENERIC])
     def is_request_valid__should_return_true_given_valid_dcv_check_request(self, validation_method):
         request = ValidRequestCreator.create_valid_dcv_mpic_request(validation_method)
         is_request_valid, validation_issues = MpicRequestValidator.is_request_valid(request, self.known_perspectives)

--- a/tests/unit/test_mpic_response_builder.py
+++ b/tests/unit/test_mpic_response_builder.py
@@ -100,7 +100,7 @@ class TestMpicResponseBuilder:
                                                       valid_by_check_type)
         response_body = MpicDcvResponse.model_validate(json.loads(response['body']))
         assert response_body.dcv_check_parameters.validation_details.challenge_value == request.dcv_check_parameters.validation_details.challenge_value
-        assert response_body.dcv_check_parameters.validation_method == request.dcv_check_parameters.validation_method
+        assert response_body.dcv_check_parameters.validation_details.validation_method == request.dcv_check_parameters.validation_details.validation_method
 
     def build_response__should_set_is_valid_to_false_when_either_check_type_is_invalid(self):
         request = ValidRequestCreator.create_valid_dcv_with_caa_mpic_request()

--- a/tests/unit/valid_request_creator.py
+++ b/tests/unit/valid_request_creator.py
@@ -1,5 +1,5 @@
 from aws_lambda_python.common_domain.check_parameters import CaaCheckParameters, DcvCheckParameters, \
-    DcvValidationDetails
+    DcvDnsGenericValidationDetails, DcvHttpGenericValidationDetails
 from aws_lambda_python.common_domain.enum.certificate_type import CertificateType
 from aws_lambda_python.common_domain.enum.dcv_validation_method import DcvValidationMethod
 from aws_lambda_python.common_domain.enum.dns_record_type import DnsRecordType
@@ -26,7 +26,6 @@ class ValidRequestCreator:
             domain_or_ip_target='test',
             orchestration_parameters=MpicRequestOrchestrationParameters(perspective_count=6, quorum_count=4),
             dcv_check_parameters=DcvCheckParameters(
-                validation_method=validation_method,
                 validation_details=ValidRequestCreator.create_validation_details(validation_method)
             )
         )
@@ -38,7 +37,6 @@ class ValidRequestCreator:
             orchestration_parameters=MpicRequestOrchestrationParameters(perspective_count=6, quorum_count=4),
             caa_check_parameters=CaaCheckParameters(certificate_type=CertificateType.TLS_SERVER),
             dcv_check_parameters=DcvCheckParameters(
-                validation_method=validation_method,
                 validation_details=ValidRequestCreator.create_validation_details(validation_method)
             )
         )
@@ -59,9 +57,7 @@ class ValidRequestCreator:
         validation_details = {}
         match validation_method:
             case DcvValidationMethod.DNS_GENERIC:
-                validation_details = DcvValidationDetails(dns_name_prefix='test', dns_record_type=DnsRecordType.A, challenge_value='test')
+                validation_details = DcvDnsGenericValidationDetails(dns_name_prefix='test', dns_record_type=DnsRecordType.A, challenge_value='test')
             case DcvValidationMethod.HTTP_GENERIC:
-                validation_details = DcvValidationDetails(http_token_path='http://example.com', challenge_value='test')  # noqa E501 (http)
-            case DcvValidationMethod.TLS_USING_ALPN:
-                validation_details = DcvValidationDetails(challenge_value='test')
+                validation_details = DcvHttpGenericValidationDetails(http_token_path='http://example.com', challenge_value='test')  # noqa E501 (http)
         return validation_details


### PR DESCRIPTION
Addresses issue https://github.com/open-mpic/aws-lambda-python/issues/18

Took the domain-object-oriented approach rather than the `exclude_none=True` approach, although we can look at that for other reasons as described in the issue.

`DcvValidationDetails` is now abstract with two concrete classes to simplify deserialization and validation. This necessitated (for cleanliness) moving the `validation_method` field into the details object. This did require a bunch of small changes because this stuff is sprinkled across many tests. Still at 96% coverage.