### PR TITLE
CAA check nonexistent domain

### DIFF
--- a/src/aws_lambda_python/mpic_caa_checker/mpic_caa_checker.py
+++ b/src/aws_lambda_python/mpic_caa_checker/mpic_caa_checker.py
@@ -50,7 +50,7 @@ class MpicCaaChecker:
                 print(f'Found a CAA record for {domain}! Response: {lookup.rrset.to_text()}')
                 rrset = lookup.rrset
                 break
-            except dns.resolver.NoAnswer:
+            except (dns.resolver.NoAnswer, dns.resolver.NXDOMAIN):
                 print(f'No CAA record found for {domain}; trying parent domain...')
                 domain = domain.parent()
             except Exception:

--- a/tests/unit/test_mpic_caa_checker.py
+++ b/tests/unit/test_mpic_caa_checker.py
@@ -56,6 +56,22 @@ class TestMpicCaaChecker:
         check_response_details = CaaCheckResponseDetails(caa_record_present=True, found_at='example.com', response=test_dns_query_answer.rrset.to_text())
         assert self.is_result_as_expected(result, True, check_response_details) is True
 
+    def check_caa__should_return_200_and_allow_issuance_given_matching_caa_record_found_in_parent_for_not_existing_domain(self, set_env_variables, mocker):
+        test_dns_query_answer = MockDnsObjectCreator.create_caa_query_answer('example.com', 0, 'issue', 'ca111.com', mocker)
+        mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: (
+            test_dns_query_answer if domain_name.to_text() == 'example.com.' else
+            (_ for _ in ()).throw(dns.resolver.NXDOMAIN)
+        ))
+        caa_request = CaaCheckRequest(domain_or_ip_target='notexisting.example.com',
+                                      caa_check_parameters=CaaCheckParameters(certificate_type=CertificateType.TLS_SERVER,
+                                                                              caa_domains=['ca111.com']))
+
+        caa_checker = MpicCaaChecker()
+        result = caa_checker.check_caa(caa_request)
+        assert result['statusCode'] == 200
+        check_response_details = CaaCheckResponseDetails(caa_record_present=True, found_at='example.com', response=test_dns_query_answer.rrset.to_text())
+        assert self.is_result_as_expected(result, True, check_response_details) is True
+        
     def check_caa__should_return_200_and_disallow_issuance_given_non_matching_caa_record_found(self, set_env_variables, mocker):
         test_dns_query_answer = MockDnsObjectCreator.create_caa_query_answer('example.com', 0, 'issue', 'ca222.com', mocker)
         mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: (

--- a/tests/unit/test_mpic_caa_checker.py
+++ b/tests/unit/test_mpic_caa_checker.py
@@ -56,7 +56,7 @@ class TestMpicCaaChecker:
         check_response_details = CaaCheckResponseDetails(caa_record_present=True, found_at='example.com', response=test_dns_query_answer.rrset.to_text())
         assert self.is_result_as_expected(result, True, check_response_details) is True
 
-    def check_caa__should_return_200_and_allow_issuance_given_matching_caa_record_found_in_parent_for_not_existing_domain(self, set_env_variables, mocker):
+    def check_caa__should_return_200_and_allow_issuance_given_matching_caa_record_found_in_parent_of_nonexistent_domain(self, set_env_variables, mocker):
         test_dns_query_answer = MockDnsObjectCreator.create_caa_query_answer('example.com', 0, 'issue', 'ca111.com', mocker)
         mocker.patch('dns.resolver.resolve', side_effect=lambda domain_name, rdtype: (
             test_dns_query_answer if domain_name.to_text() == 'example.com.' else


### PR DESCRIPTION
Hello everyone,

I have run some tests on the CAA Checker and encountered an issue when performing a CAA records check for a non-existent domain.

### My test data:
**domain**: test1234.actalis.it
**request and response**:

```json
{
   "check_type":"caa",
   "domain_or_ip_target":"test1234.actalis.it",
   "caa_check_parameters":{
      "certificate_type":"tls-server",
      "caa_domains":[
         "digicert.com"
      ]
   }
}

{
   "request_orchestration_parameters":null,
   "actual_orchestration_parameters":{
      "perspective_count":3,
      "quorum_count":2,
      "attempt_count":1
   },
   "is_valid":false,
   "check_type":"caa",
   "perspectives":[
      {
         "perspective":"ripe.eu-central-1",
         "check_passed":false,
         "errors":[
            {
               "error_type":"mpic_error:caa_checker:lookup",
               "error_message":"There was an error looking up the CAA record."
            }
         ],
         "timestamp_ns":1729078541591314639,
         "check_type":"caa",
         "details":{
            "caa_record_present":false,
            "found_at":null,
            "response":null
         }
      },
      {
         "perspective":"arin.us-east-2",
         "check_passed":false,
         "errors":[
            {
               "error_type":"mpic_error:caa_checker:lookup",
               "error_message":"There was an error looking up the CAA record."
            }
         ],
         "timestamp_ns":1729078541954948229,
         "check_type":"caa",
         "details":{
            "caa_record_present":false,
            "found_at":null,
            "response":null
         }
      },
      {
         "perspective":"apnic.ap-northeast-2",
         "check_passed":false,
         "errors":[
            {
               "error_type":"mpic_error:caa_checker:lookup",
               "error_message":"There was an error looking up the CAA record."
            }
         ],
         "timestamp_ns":1729078542445721238,
         "check_type":"caa",
         "details":{
            "caa_record_present":false,
            "found_at":null,
            "response":null
         }
      }
   ],
   "caa_check_parameters":{
      "certificate_type":"tls-server",
      "caa_domains":[
         "digicert.com"
      ]
   }
}

```
After analyzing the logs, I found that the error was caused by an exception thrown by the **dns.resolver.resolve** method. According to the DNSPython documentation ( [DNSPython Docs](https://dnspython.readthedocs.io/en/latest/resolver-class.html#dns.resolver.Resolver.resolve) ) the exception was a **dns.resolver.NXDOMAIN** exception. 
I have added the handling of the **dns.resolver.NXDOMAIN** exception in the **find_caa_record_and_domain** method of the **MpicCaaChecker** class, as can be seen in the pull request.

After the fix the response is:

```json
{
   "request_orchestration_parameters":null,
   "actual_orchestration_parameters":{
      "perspective_count":3,
      "quorum_count":2,
      "attempt_count":1
   },
   "is_valid":true,
   "check_type":"caa",
   "perspectives":[
      {
         "perspective":"ripe.eu-central-1",
         "check_passed":true,
         "errors":null,
         "timestamp_ns":1729069988289162941,
         "check_type":"caa",
         "details":{
            "caa_record_present":true,
            "found_at":"actalis.it",
            "response":"actalis.it. 3600 IN CAA 0 issue \"digicert.com\"\nactalis.it. 3600 IN CAA 0 issue \"actalis.it\""
         }
      },
      {
         "perspective":"arin.us-east-2",
         "check_passed":true,
         "errors":null,
         "timestamp_ns":1729069988857107863,
         "check_type":"caa",
         "details":{
            "caa_record_present":true,
            "found_at":"actalis.it",
            "response":"actalis.it. 3600 IN CAA 0 issue \"actalis.it\"\nactalis.it. 3600 IN CAA 0 issue \"digicert.com\""
         }
      },
      {
         "perspective":"apnic.ap-northeast-2",
         "check_passed":true,
         "errors":null,
         "timestamp_ns":1729069989428864639,
         "check_type":"caa",
         "details":{
            "caa_record_present":true,
            "found_at":"actalis.it",
            "response":"actalis.it. 3600 IN CAA 0 issue \"digicert.com\"\nactalis.it. 3600 IN CAA 0 issue \"actalis.it\""
         }
      }
   ],
   "caa_check_parameters":{
      "certificate_type":"tls-server",
      "caa_domains":[
         "digicert.com"
      ]
   }
}
```