### PR TITLE
DCV and CAA lambda handlers expect objects instead of dicts

### DIFF
--- a/src/aws_lambda_mpic/mpic_caa_checker_lambda/mpic_caa_checker_lambda_function.py
+++ b/src/aws_lambda_mpic/mpic_caa_checker_lambda/mpic_caa_checker_lambda_function.py
@@ -1,7 +1,11 @@
+from aws_lambda_powertools.utilities.parser import event_parser
+
 from open_mpic_core.common_domain.check_request import CaaCheckRequest
 from open_mpic_core.common_domain.remote_perspective import RemotePerspective
 from open_mpic_core.mpic_caa_checker.mpic_caa_checker import MpicCaaChecker
 import os
+
+from open_mpic_core.mpic_coordinator.domain.mpic_request import MpicCaaRequest
 
 
 class MpicCaaCheckerLambdaHandler:
@@ -10,8 +14,7 @@ class MpicCaaCheckerLambdaHandler:
         self.default_caa_domain_list = os.environ['default_caa_domains'].split("|")
         self.caa_checker = MpicCaaChecker(self.default_caa_domain_list, self.perspective)
 
-    def process_invocation(self, caa_request_dict: dict):
-        caa_request = CaaCheckRequest.model_validate(caa_request_dict)
+    def process_invocation(self, caa_request: CaaCheckRequest):
         caa_response = self.caa_checker.check_caa(caa_request)
         result = {
             'statusCode': 200,  # note: must be snakeCase
@@ -37,5 +40,6 @@ def get_handler() -> MpicCaaCheckerLambdaHandler:
 
 # noinspection PyUnusedLocal
 # for now, we are not using context, but it is required by the lambda handler signature
-def lambda_handler(event, context):  # AWS Lambda entry point
+@event_parser(model=CaaCheckRequest)
+def lambda_handler(event: CaaCheckRequest, context):  # AWS Lambda entry point
     return get_handler().process_invocation(event)

--- a/src/aws_lambda_mpic/mpic_caa_checker_lambda/mpic_caa_checker_lambda_function.py
+++ b/src/aws_lambda_mpic/mpic_caa_checker_lambda/mpic_caa_checker_lambda_function.py
@@ -5,8 +5,6 @@ from open_mpic_core.common_domain.remote_perspective import RemotePerspective
 from open_mpic_core.mpic_caa_checker.mpic_caa_checker import MpicCaaChecker
 import os
 
-from open_mpic_core.mpic_coordinator.domain.mpic_request import MpicCaaRequest
-
 
 class MpicCaaCheckerLambdaHandler:
     def __init__(self):

--- a/src/aws_lambda_mpic/mpic_dcv_checker_lambda/mpic_dcv_checker_lambda_function.py
+++ b/src/aws_lambda_mpic/mpic_dcv_checker_lambda/mpic_dcv_checker_lambda_function.py
@@ -14,6 +14,11 @@ class MpicDcvCheckerLambdaHandler:
     def process_invocation(self, dcv_request: DcvCheckRequest):
         dcv_response = self.dcv_checker.check_dcv(dcv_request)
         status_code = 200
+        if dcv_response.errors is not None and len(dcv_response.errors) > 0:
+            if dcv_response.errors[0].error_type == '404':
+                status_code = 404
+            else:
+                status_code = 500
         result = {
             'statusCode': status_code,
             'headers': {'Content-Type': 'application/json'},

--- a/src/aws_lambda_mpic/mpic_dcv_checker_lambda/mpic_dcv_checker_lambda_function.py
+++ b/src/aws_lambda_mpic/mpic_dcv_checker_lambda/mpic_dcv_checker_lambda_function.py
@@ -1,3 +1,5 @@
+from aws_lambda_powertools.utilities.parser import event_parser
+
 from open_mpic_core.common_domain.check_request import DcvCheckRequest
 from open_mpic_core.common_domain.remote_perspective import RemotePerspective
 from open_mpic_core.mpic_dcv_checker.mpic_dcv_checker import MpicDcvChecker
@@ -12,11 +14,6 @@ class MpicDcvCheckerLambdaHandler:
     def process_invocation(self, dcv_request: DcvCheckRequest):
         dcv_response = self.dcv_checker.check_dcv(dcv_request)
         status_code = 200
-        if dcv_response.errors is not None and len(dcv_response.errors) > 0:
-            if dcv_response.errors[0].error_type == '404':
-                status_code = 404
-            else:
-                status_code = 500
         result = {
             'statusCode': status_code,
             'headers': {'Content-Type': 'application/json'},
@@ -41,5 +38,6 @@ def get_handler() -> MpicDcvCheckerLambdaHandler:
 
 # noinspection PyUnusedLocal
 # for now, we are not using context, but it is required by the lambda handler signature
-def lambda_handler(event, context):  # AWS Lambda entry point
+@event_parser(model=DcvCheckRequest)
+def lambda_handler(event: DcvCheckRequest, context):  # AWS Lambda entry point
     return get_handler().process_invocation(event)


### PR DESCRIPTION
To be consistent with the Coordinator lambda, DCV and CAA lambda handlers should expect domain objects instead of dicts.
Thanks @lmarte78 for making this inconsistency apparent.