### PR TITLE
Improve exception handling for coordinator Lambda function

### DIFF
--- a/src/aws_lambda_mpic/mpic_coordinator_lambda/mpic_coordinator_lambda_function.py
+++ b/src/aws_lambda_mpic/mpic_coordinator_lambda/mpic_coordinator_lambda_function.py
@@ -128,6 +128,7 @@ def get_handler() -> MpicCoordinatorLambdaHandler:
         _handler = MpicCoordinatorLambdaHandler()
     return _handler
 
+
 def handle_lambda_exceptions(func):
     def wrapper(*args, **kwargs):
         try:
@@ -148,6 +149,7 @@ def handle_lambda_exceptions(func):
                 'body': json.dumps({'error': str(e)})
             }
     return wrapper
+
 
 # noinspection PyUnusedLocal
 # for now, we are not using context, but it is required by the lambda handler signature

--- a/src/aws_lambda_mpic/mpic_coordinator_lambda/mpic_coordinator_lambda_function.py
+++ b/src/aws_lambda_mpic/mpic_coordinator_lambda/mpic_coordinator_lambda_function.py
@@ -7,6 +7,7 @@ from open_mpic_core.common_domain.check_request import BaseCheckRequest
 from open_mpic_core.common_domain.check_response import CheckResponse
 from open_mpic_core.mpic_coordinator.domain.mpic_request import MpicRequest
 from open_mpic_core.mpic_coordinator.domain.mpic_request_validation_error import MpicRequestValidationError
+from open_mpic_core.mpic_coordinator.messages.mpic_request_validation_messages import MpicRequestValidationMessages
 from open_mpic_core.mpic_coordinator.mpic_coordinator import MpicCoordinator, MpicCoordinatorConfiguration
 from open_mpic_core.common_domain.enum.check_type import CheckType
 from open_mpic_core.common_domain.remote_perspective import RemotePerspective
@@ -127,12 +128,30 @@ def get_handler() -> MpicCoordinatorLambdaHandler:
         _handler = MpicCoordinatorLambdaHandler()
     return _handler
 
+def handle_lambda_exceptions(func):
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ValidationError as validation_error:
+            return {
+                'statusCode': 400,
+                'headers': {'Content-Type': 'application/json'},
+                'body': json.dumps({
+                    'error': MpicRequestValidationMessages.REQUEST_VALIDATION_FAILED.key,
+                    'validation_issues': validation_error.errors()
+                })
+            }
+        except Exception as e:
+            return {
+                'statusCode': 500,
+                'headers': {'Content-Type': 'application/json'},
+                'body': json.dumps({'error': str(e)})
+            }
+    return wrapper
 
-# TODO We need to find a way to bring back transparent error messages with this new parsing model.
-#      If the parsing to the MPIC request fails, it returns system internal server errors instead of returning
-#      the pydantic error message.
 # noinspection PyUnusedLocal
 # for now, we are not using context, but it is required by the lambda handler signature
+@handle_lambda_exceptions
 @event_parser(model=MpicRequest, envelope=envelopes.ApiGatewayEnvelope)  # AWS Lambda Powertools decorator
 def lambda_handler(event: MpicRequest, context):  # AWS Lambda entry point
     return get_handler().process_invocation(event)

--- a/tests/integration/test_deployed_mpic_api.py
+++ b/tests/integration/test_deployed_mpic_api.py
@@ -172,7 +172,7 @@ class TestDeployedMpicApi:
         response_body = json.loads(response.text)
         print("\nResponse:\n", json.dumps(response_body, indent=4))  # pretty print response body
 
-    def api_should_return_500_given_invalid_orchestration_parameters_in_request(self, api_client):
+    def api_should_return_400_given_invalid_orchestration_parameters_in_request(self, api_client):
         request = MpicCaaRequest(
             domain_or_ip_target='example.com',
             orchestration_parameters=MpicRequestOrchestrationParameters(perspective_count=3, quorum_count=5),  # invalid quorum count
@@ -181,14 +181,13 @@ class TestDeployedMpicApi:
 
         print("\nRequest:\n", json.dumps(request.model_dump(), indent=4))  # pretty print request body
         response = api_client.post(MPIC_REQUEST_PATH, json.dumps(request.model_dump()))
-        assert response.status_code == 500
+        assert response.status_code == 400
         response_body = json.loads(response.text)
         print("\nResponse:\n", json.dumps(response_body, indent=4))  # pretty print response body
         assert response_body['error'] == MpicRequestValidationMessages.REQUEST_VALIDATION_FAILED.key
-        # We lost error detail in the last push.
-        #assert any(issue['issue_type'] == MpicRequestValidationMessages.INVALID_QUORUM_COUNT.key for issue in response_body['validation_issues'])
+        assert any(issue['issue_type'] == MpicRequestValidationMessages.INVALID_QUORUM_COUNT.key for issue in response_body['validation_issues'])
 
-    def api_should_return_502_given_invalid_check_type_in_request(self, api_client):
+    def api_should_return_400_given_invalid_check_type_in_request(self, api_client):
         request = MpicCaaRequest(
             domain_or_ip_target='example.com',
             orchestration_parameters=MpicRequestOrchestrationParameters(perspective_count=3, quorum_count=2),
@@ -198,8 +197,7 @@ class TestDeployedMpicApi:
 
         print("\nRequest:\n", json.dumps(request.model_dump(), indent=4))  # pretty print request body
         response = api_client.post(MPIC_REQUEST_PATH, json.dumps(request.model_dump()))
-        assert response.status_code == 502
-        #response_body = json.loads(response.text)
-        #print("\nResponse:\n", json.dumps(response_body, indent=4))
-        # We last error details in the last push.
-        #assert response_body['error'] == MpicRequestValidationMessages.REQUEST_VALIDATION_FAILED.key
+        assert response.status_code == 400
+        response_body = json.loads(response.text)
+        print("\nResponse:\n", json.dumps(response_body, indent=4))
+        assert response_body['error'] == MpicRequestValidationMessages.REQUEST_VALIDATION_FAILED.key

--- a/tests/unit/aws_lambda_mpic/test_mpic_coordinator_lambda.py
+++ b/tests/unit/aws_lambda_mpic/test_mpic_coordinator_lambda.py
@@ -74,13 +74,13 @@ class TestMpicCoordinatorLambda:
         result_body = json.loads(result['body'])
         assert result_body['validation_issues'][0]['type'] == 'union_tag_invalid'
 
-    def lambda_handler__should_return_500_error_given_logically_invalid_request(self):
+    def lambda_handler__should_return_400_error_given_logically_invalid_request(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         request.orchestration_parameters.perspective_count = 1
         api_request = TestMpicCoordinatorLambda.create_api_gateway_request()
         api_request.body = request.model_dump_json()
         result = mpic_coordinator_lambda_function.lambda_handler(api_request, None)
-        assert result['statusCode'] == 500
+        assert result['statusCode'] == 400
 
     def lambda_handler__should_return_500_error_given_other_unexpected_errors(self, set_env_variables, mocker):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()

--- a/tests/unit/aws_lambda_mpic/test_mpic_coordinator_lambda.py
+++ b/tests/unit/aws_lambda_mpic/test_mpic_coordinator_lambda.py
@@ -54,32 +54,40 @@ class TestMpicCoordinatorLambda:
         # hijacking the value of 'perspective' to verify that the right arguments got passed to the call
         assert check_response.perspective_code == dcv_check_request.domain_or_ip_target
 
-    def lambda_handler__should_return_error_given_invalid_request_body(self):
+    def lambda_handler__should_return_400_error_and_details_given_invalid_request_body(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         request.domain_or_ip_target = None
         api_request = TestMpicCoordinatorLambda.create_api_gateway_request()
         api_request.body = request.model_dump_json()
-        with pytest.raises(ValidationError) as validation_error:
-            mpic_coordinator_lambda_function.lambda_handler(api_request, None)
-            assert validation_error.value.errors() == [{'loc': ('body',), 'msg': 'field required', 'type': 'value_error.missing'}]
+        result = mpic_coordinator_lambda_function.lambda_handler(api_request, None)
+        assert result['statusCode'] == 400
+        result_body = json.loads(result['body'])
+        assert result_body['validation_issues'][0]['type'] == 'string_type'
 
-    def lambda_handler__should_return_error_given_invalid_check_type(self):
+    def lambda_handler__should_return_400_error_and_details_given_invalid_check_type(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         request.check_type = 'invalid_check_type'
         api_request = TestMpicCoordinatorLambda.create_api_gateway_request()
         api_request.body = request.model_dump_json()
-        with pytest.raises(ValidationError) as validation_error:
-            mpic_coordinator_lambda_function.lambda_handler(api_request, None)
-            assert validation_error.value.errors() == [
-                {'loc': ('body', 'check_type'),
-                 'msg': 'value is not a valid enumeration member; permitted: \'DCV\', \'CAA\'', 'type': 'type_error.enum'}
-            ]
+        result = mpic_coordinator_lambda_function.lambda_handler(api_request, None)
+        assert result['statusCode'] == 400
+        result_body = json.loads(result['body'])
+        assert result_body['validation_issues'][0]['type'] == 'union_tag_invalid'
 
     def lambda_handler__should_return_500_error_given_logically_invalid_request(self):
         request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
         request.orchestration_parameters.perspective_count = 1
         api_request = TestMpicCoordinatorLambda.create_api_gateway_request()
         api_request.body = request.model_dump_json()
+        result = mpic_coordinator_lambda_function.lambda_handler(api_request, None)
+        assert result['statusCode'] == 500
+
+    def lambda_handler__should_return_500_error_given_other_unexpected_errors(self, set_env_variables, mocker):
+        request = ValidMpicRequestCreator.create_valid_dcv_mpic_request()
+        api_request = TestMpicCoordinatorLambda.create_api_gateway_request()
+        api_request.body = request.model_dump_json()
+        mocker.patch('open_mpic_core.mpic_coordinator.mpic_coordinator.MpicCoordinator.coordinate_mpic',
+                     side_effect=Exception('Something went wrong'))
         result = mpic_coordinator_lambda_function.lambda_handler(api_request, None)
         assert result['statusCode'] == 500
 


### PR DESCRIPTION
Instead of always failing like this:

```
{
    "message": "Internal server error"
}
```

This allows for errors to be returned to the client like this:

```
{
    "error": "request-validation-failed",
    "validation_issues": [
        {
            "type": "union_tag_not_found",
            "loc": [],
            "msg": "Unable to extract tag using discriminator 'check_type'",
            "input": {
                "domain_or_ip_target": "3accfa494c413f7c6773091c1a7f5207.test.dcv-inspector.com"
            },
            "ctx": {
                "discriminator": "'check_type'"
            },
            "url": "https://errors.pydantic.dev/2.8/v/union_tag_not_found"
        }
    ]
}
```
